### PR TITLE
[refactor] thread/process 패키지 파일 구조 정리 및 abWorkerThread 잔재 복구 (v2.3.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-library"
-version = "2.2.8"
+version = "2.3.0"
 description = "python library"
 requires-python = ">=3.11"
 dependencies = [

--- a/src/python_library/job_queue/README.md
+++ b/src/python_library/job_queue/README.md
@@ -35,7 +35,7 @@ class IJobQueue(ABC):
 ## 스레드 안전성
 
 `JobQueue` 자체는 스레드 안전하지 않다.
-`MultiThreadManager`와 `abWorkerThread`에서 `Lock`을 함께 사용해 안전하게 접근한다.
+`MultiThreadManager`와 `QueueThread`에서 `Lock`을 함께 사용해 안전하게 접근한다.
 직접 `JobQueue`를 사용할 때는 `Lock`을 별도로 관리해야 한다.
 
 ---

--- a/src/python_library/process/multi_process_manager.py
+++ b/src/python_library/process/multi_process_manager.py
@@ -4,7 +4,7 @@ from queue import Queue
 from typing import List, Optional, MutableMapping
 
 from python_library.job.job import IJob
-from python_library.process.process import IQueueProcess
+from python_library.process.queue_process import IQueueProcess
 from python_library.thread.thread import abThread
 
 

--- a/src/python_library/process/process.py
+++ b/src/python_library/process/process.py
@@ -1,10 +1,6 @@
-from queue import Queue
-from threading import Lock
 from multiprocessing import Process, Event
 from abc import ABC, abstractmethod
-from typing import Optional, MutableMapping
 
-from python_library.job.job import IJob
 from python_library.utils.class_name_generator import ClassNameGenerator
 
 
@@ -34,33 +30,6 @@ class IProcess(ABC):
 
     @abstractmethod
     def is_running(self) -> bool: ...
-
-
-class IQueueProcess(IProcess):
-
-    @abstractmethod
-    def set_shared_job_queue(self, shared_job_queue: Queue, shared_job_queue_lock: Lock) -> None: ...
-
-    @abstractmethod
-    def push_shared_job_queue(self, job: IJob) -> None: ...
-
-    @abstractmethod
-    def pop_shared_job_queue(self) -> IJob | None: ...
-
-    @abstractmethod
-    def size_shared_job_queue(self) -> int: ...
-
-    @abstractmethod
-    def set_shared_queue(self, shared_queue: MutableMapping[str, Queue], shared_queue_lock: MutableMapping[str, Lock]) -> None: ...
-
-    @abstractmethod
-    def push_shared_queue(self, process_name: str, job: IJob) -> None: ...
-
-    @abstractmethod
-    def pop_shared_queue(self, process_name: str) -> Optional[IJob]: ...
-
-    @abstractmethod
-    def size_shared_queue(self, process_name: str) -> int: ...
 
 
 class abProcess(Process, IProcess):
@@ -95,73 +64,7 @@ class abProcess(Process, IProcess):
         pass
 
 
-class QueueProcess(abProcess, IQueueProcess):
-
-    def __init__(self, name: str | None = None) -> None:
-        super().__init__(name=name)
-        self._shared_job_queue: Optional[Queue] = None
-        self._shared_job_queue_lock: Optional[Lock] = None
-        self._shared_queue: Optional[MutableMapping[str, Queue]] = None
-        self._shared_queue_lock: Optional[MutableMapping[str, Lock]] = None
-
-    ##########################################################################
-
-    def set_shared_job_queue(self, shared_job_queue: Queue, shared_job_queue_lock: Lock) -> None:
-        self._shared_job_queue = shared_job_queue
-        self._shared_job_queue_lock = shared_job_queue_lock
-
-    def push_shared_job_queue(self, job: IJob) -> None:
-        with self._shared_job_queue_lock:
-            self._shared_job_queue.put(job)
-
-    def pop_shared_job_queue(self) -> IJob | None:
-        with self._shared_job_queue_lock:
-            if self._shared_job_queue.empty():
-                return None
-            return self._shared_job_queue.get()
-
-    def size_shared_job_queue(self) -> int:
-        with self._shared_job_queue_lock:
-            return self._shared_job_queue.qsize()
-
-    ##########################################################################
-
-    def set_shared_queue(self, shared_queue: MutableMapping[str, Queue], shared_queue_lock: MutableMapping[str, Lock]) -> None:
-        self._shared_queue = shared_queue
-        self._shared_queue_lock = shared_queue_lock
-
-    def push_shared_queue(self, process_name: str, job: IJob) -> None:
-        assert self._shared_queue_lock is not None
-        with self._shared_queue_lock[process_name]:
-            self._shared_queue[process_name].put(job)
-
-    def pop_shared_queue(self, process_name: str) -> Optional[IJob]:
-        assert self._shared_queue_lock is not None
-        with self._shared_queue_lock[process_name]:
-            if self._shared_queue[process_name].empty():
-                return None
-            return self._shared_queue[process_name].get()
-
-    def size_shared_queue(self, process_name: str) -> int:
-        assert self._shared_queue_lock is not None
-        with self._shared_queue_lock[process_name]:
-            return self._shared_queue[process_name].qsize()
-
-
 class abProcessing(abProcess):
-    def run(self) -> None:
-        try:
-            while not self.is_stop():
-                self.action()
-        except Exception as e:
-            raise e
-
-    @abstractmethod
-    def action(self) -> None:
-        pass
-
-
-class QueueProcessing(QueueProcess):
     def run(self) -> None:
         try:
             while not self.is_stop():

--- a/src/python_library/process/queue_process.py
+++ b/src/python_library/process/queue_process.py
@@ -1,0 +1,100 @@
+from queue import Queue
+from threading import Lock
+from abc import abstractmethod
+from typing import Optional, MutableMapping
+
+from python_library.job.job import IJob
+from python_library.process.process import IProcess, abProcess
+
+
+class IQueueProcess(IProcess):
+
+    @abstractmethod
+    def set_shared_job_queue(self, shared_job_queue: Queue, shared_job_queue_lock: Lock) -> None: ...
+
+    @abstractmethod
+    def push_shared_job_queue(self, job: IJob) -> None: ...
+
+    @abstractmethod
+    def pop_shared_job_queue(self) -> IJob | None: ...
+
+    @abstractmethod
+    def size_shared_job_queue(self) -> int: ...
+
+    @abstractmethod
+    def set_shared_queue(self, shared_queue: MutableMapping[str, Queue], shared_queue_lock: MutableMapping[str, Lock]) -> None: ...
+
+    @abstractmethod
+    def push_shared_queue(self, process_name: str, job: IJob) -> None: ...
+
+    @abstractmethod
+    def pop_shared_queue(self, process_name: str) -> Optional[IJob]: ...
+
+    @abstractmethod
+    def size_shared_queue(self, process_name: str) -> int: ...
+
+
+class QueueProcess(abProcess, IQueueProcess):
+
+    def __init__(self, name: str | None = None) -> None:
+        super().__init__(name=name)
+        self._shared_job_queue: Optional[Queue] = None
+        self._shared_job_queue_lock: Optional[Lock] = None
+        self._shared_queue: Optional[MutableMapping[str, Queue]] = None
+        self._shared_queue_lock: Optional[MutableMapping[str, Lock]] = None
+
+    ##########################################################################
+
+    def set_shared_job_queue(self, shared_job_queue: Queue, shared_job_queue_lock: Lock) -> None:
+        self._shared_job_queue = shared_job_queue
+        self._shared_job_queue_lock = shared_job_queue_lock
+
+    def push_shared_job_queue(self, job: IJob) -> None:
+        with self._shared_job_queue_lock:
+            self._shared_job_queue.put(job)
+
+    def pop_shared_job_queue(self) -> IJob | None:
+        with self._shared_job_queue_lock:
+            if self._shared_job_queue.empty():
+                return None
+            return self._shared_job_queue.get()
+
+    def size_shared_job_queue(self) -> int:
+        with self._shared_job_queue_lock:
+            return self._shared_job_queue.qsize()
+
+    ##########################################################################
+
+    def set_shared_queue(self, shared_queue: MutableMapping[str, Queue], shared_queue_lock: MutableMapping[str, Lock]) -> None:
+        self._shared_queue = shared_queue
+        self._shared_queue_lock = shared_queue_lock
+
+    def push_shared_queue(self, process_name: str, job: IJob) -> None:
+        assert self._shared_queue_lock is not None
+        with self._shared_queue_lock[process_name]:
+            self._shared_queue[process_name].put(job)
+
+    def pop_shared_queue(self, process_name: str) -> Optional[IJob]:
+        assert self._shared_queue_lock is not None
+        with self._shared_queue_lock[process_name]:
+            if self._shared_queue[process_name].empty():
+                return None
+            return self._shared_queue[process_name].get()
+
+    def size_shared_queue(self, process_name: str) -> int:
+        assert self._shared_queue_lock is not None
+        with self._shared_queue_lock[process_name]:
+            return self._shared_queue[process_name].qsize()
+
+
+class QueueProcessing(QueueProcess):
+    def run(self) -> None:
+        try:
+            while not self.is_stop():
+                self.action()
+        except Exception as e:
+            raise e
+
+    @abstractmethod
+    def action(self) -> None:
+        pass

--- a/src/python_library/thread/README.md
+++ b/src/python_library/thread/README.md
@@ -9,8 +9,9 @@
 threading.Thread
 └── abThread (ABC)              # 스레드 기본 추상 클래스
     ├── abThreading (ABC)       # 반복 실행 스레드 (stop 신호까지 루프)
-    └── abWorkerThread (ABC)    # 공유 큐를 사용하는 작업 스레드
-        └── MultiThreadManager  # 여러 Worker Thread를 묶어서 관리
+    └── QueueThread (ABC)       # 공유 큐를 사용하는 작업 스레드
+        ├── QueueThreading      # 반복 실행 + 공유 큐
+        └── MultiThreadManager  # 여러 QueueThread를 묶어서 관리
 ```
 
 ---
@@ -33,14 +34,14 @@ thread = MyThread()
 thread.start()
 ```
 
-### 2. 워커 스레드 (abWorkerThread)
+### 2. 큐 기반 스레드 (QueueThread)
 
 공유 큐에서 Job을 꺼내 처리하는 패턴.
 
 ```python
-from python_library.thread.worker_thread import abWorkerThread
+from python_library.thread.queue_thread import QueueThread
 
-class MyWorkerThread(abWorkerThread):
+class MyWorkerThread(QueueThread):
     def action(self) -> None:
         while True:
             time.sleep(1)
@@ -121,7 +122,7 @@ while True:
 
 ### MultiThreadManager
 
-`abWorkerThread`를 상속하므로 그 자체도 스레드로 동작한다.
+`QueueThread`를 상속하므로 그 자체도 스레드로 동작한다.
 `start()` 호출 시 하위 스레드들을 모두 시작하고, `action()`을 실행한 후 `join()`으로 완료를 기다린다.
 
 ### stop 전파

--- a/src/python_library/thread/multi_thread_manager.py
+++ b/src/python_library/thread/multi_thread_manager.py
@@ -3,8 +3,8 @@ from typing import List, Dict, Optional
 from abc import abstractmethod
 
 from python_library.job_queue.job_queue import IJobQueue, JobQueue
-from python_library.thread.thread import abThread, IQueueThread
-from python_library.thread.worker_thread import QueueThread
+from python_library.thread.thread import abThread
+from python_library.thread.queue_thread import IQueueThread, QueueThread
 
 
 class MultiThreadManager(QueueThread):

--- a/src/python_library/thread/queue_thread.py
+++ b/src/python_library/thread/queue_thread.py
@@ -4,7 +4,34 @@ from threading import Lock
 
 from python_library.job.job import IJob
 from python_library.job_queue.job_queue import IJobQueue, JobQueue
-from python_library.thread.thread import abThread, IQueueThread
+from python_library.thread.thread import IThread, abThread
+
+
+class IQueueThread(IThread):
+
+    @abstractmethod
+    def set_shared_job_queue(self, shared_job_queue: IJobQueue, shared_job_queue_lock: Lock) -> None: ...
+
+    @abstractmethod
+    def push_shared_job_queue(self, job: IJob) -> None: ...
+
+    @abstractmethod
+    def pop_shared_job_queue(self) -> IJob | None: ...
+
+    @abstractmethod
+    def size_shared_job_queue(self) -> int: ...
+
+    @abstractmethod
+    def set_shared_queue(self, shared_queue: Dict[str, IJobQueue], shared_queue_lock: Dict[str, Lock]) -> None: ...
+
+    @abstractmethod
+    def push_shared_queue(self, name: str, job: IJob) -> None: ...
+
+    @abstractmethod
+    def pop_shared_queue(self, name: str) -> Optional[IJob]: ...
+
+    @abstractmethod
+    def size_shared_queue(self, name: str) -> int: ...
 
 
 class QueueThread(abThread, IQueueThread):

--- a/src/python_library/thread/thread.py
+++ b/src/python_library/thread/thread.py
@@ -1,9 +1,7 @@
 from abc import ABC, abstractmethod
-from threading import Thread, Event, Lock
-from typing import Optional, Dict
+from threading import Thread, Event
+from typing import Optional
 
-from python_library.job.job import IJob
-from python_library.job_queue.job_queue import IJobQueue
 from python_library.utils.class_name_generator import ClassNameGenerator
 
 
@@ -30,33 +28,6 @@ class IThread(ABC):
 
     @abstractmethod
     def is_running(self) -> bool: ...
-
-
-class IQueueThread(IThread):
-
-    @abstractmethod
-    def set_shared_job_queue(self, shared_job_queue: IJobQueue, shared_job_queue_lock: Lock) -> None: ...
-
-    @abstractmethod
-    def push_shared_job_queue(self, job: IJob) -> None: ...
-
-    @abstractmethod
-    def pop_shared_job_queue(self) -> IJob | None: ...
-
-    @abstractmethod
-    def size_shared_job_queue(self) -> int: ...
-
-    @abstractmethod
-    def set_shared_queue(self, shared_queue: Dict[str, IJobQueue], shared_queue_lock: Dict[str, Lock]) -> None: ...
-
-    @abstractmethod
-    def push_shared_queue(self, name: str, job: IJob) -> None: ...
-
-    @abstractmethod
-    def pop_shared_queue(self, name: str) -> Optional[IJob]: ...
-
-    @abstractmethod
-    def size_shared_queue(self, name: str) -> int: ...
 
 
 class abThread(Thread, IThread):

--- a/tests/test_multi_thread/test_multi_thread.py
+++ b/tests/test_multi_thread/test_multi_thread.py
@@ -2,7 +2,7 @@ import time
 
 from python_library.job.job import IJob
 from python_library.thread.multi_thread_manager import MultiThreadManager
-from python_library.thread.worker_thread import abWorkerThread
+from python_library.thread.queue_thread import QueueThread
 
 
 class TestJob(IJob):
@@ -14,7 +14,7 @@ class TestJob(IJob):
         pass
 
 
-class TestWorkerThread(abWorkerThread):
+class TestWorkerThread(QueueThread):
     def __init__(self) -> None:
         super().__init__()
 

--- a/uv.lock
+++ b/uv.lock
@@ -333,50 +333,6 @@ wheels = [
 ]
 
 [[package]]
-name = "oncx-core"
-version = "2.2.5"
-source = { virtual = "." }
-dependencies = [
-    { name = "argon2-cffi" },
-    { name = "boto3" },
-    { name = "pyarrow" },
-    { name = "rich" },
-]
-
-[package.optional-dependencies]
-postgres = [
-    { name = "psycopg", extra = ["binary"] },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pre-commit" },
-    { name = "pyright" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "argon2-cffi", specifier = ">=25.1.0" },
-    { name = "boto3", specifier = ">=1.42.0" },
-    { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.2.1" },
-    { name = "pyarrow", specifier = ">=22.0.0" },
-    { name = "rich", specifier = ">=14.2.0" },
-]
-provides-extras = ["postgres"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pre-commit", specifier = ">=4.5.0" },
-    { name = "pyright", specifier = ">=1.1.407" },
-    { name = "pytest", specifier = ">=9.0.1" },
-    { name = "pytest-cov", specifier = ">=7.0.0" },
-    { name = "ruff", specifier = ">=0.14.6" },
-]
-
-[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -609,6 +565,50 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-library"
+version = "2.3.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "argon2-cffi" },
+    { name = "boto3" },
+    { name = "pyarrow" },
+    { name = "rich" },
+]
+
+[package.optional-dependencies]
+postgres = [
+    { name = "psycopg", extra = ["binary"] },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pre-commit" },
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "argon2-cffi", specifier = ">=25.1.0" },
+    { name = "boto3", specifier = ">=1.42.0" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.2.1" },
+    { name = "pyarrow", specifier = ">=22.0.0" },
+    { name = "rich", specifier = ">=14.2.0" },
+]
+provides-extras = ["postgres"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pre-commit", specifier = ">=4.5.0" },
+    { name = "pyright", specifier = ">=1.1.407" },
+    { name = "pytest", specifier = ">=9.0.1" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "ruff", specifier = ">=0.14.6" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- thread: `worker_thread.py` → `queue_thread.py` 리네임 (파일명과 `QueueThread` 클래스명 일치)
- thread/process: queue 도메인 응집을 위해 `IQueueThread`, `IQueueProcess`를 각각 `queue_thread.py`, `queue_process.py`로 이동
- process: `queue_process.py` 신설 (`IQueueProcess`, `QueueProcess`, `QueueProcessing` 이동) — thread 패키지와 파일 구조 대칭
- `abWorkerThread` 잔재 참조 복구 (`test_multi_thread.py` ImportError 상태였음, `thread/README.md`, `job_queue/README.md`)
- 버전 `2.2.8 → 2.3.0` (breaking, MINOR) 및 `uv.lock` 동기화

## Related Issue
close #15