### PR TITLE
[feat] #23 state machine 모듈 추가 — Tetris C# 4-layer 패턴

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-library"
-version = "2.3.1"
+version = "2.4.0"
 description = "python library"
 requires-python = ">=3.11"
 dependencies = [

--- a/src/python_library/state/__init__.py
+++ b/src/python_library/state/__init__.py
@@ -1,0 +1,11 @@
+from python_library.state.state import abState
+from python_library.state.state_components import StateComponents
+from python_library.state.state_lists import StateLists
+from python_library.state.state_manager import StateManager
+
+__all__ = [
+    "abState",
+    "StateComponents",
+    "StateLists",
+    "StateManager",
+]

--- a/src/python_library/state/state.py
+++ b/src/python_library/state/state.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Any, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from python_library.state.state_lists import StateLists
+    from python_library.state.state_manager import StateManager
+    from python_library.state.state_components import StateComponents
+
+
+class abState(ABC):
+    """
+    Tetris C# abState 동등 클래스.
+
+    Lifecycle:
+      base_on_enter(state_param_dto)
+        -> _is_run_proc_once 리셋
+        -> parents_process cache
+        -> state_param_dto 저장
+        -> on_enter()
+
+      base_on_proc_every_frame()
+        -> on_proc_once() 1회
+        -> on_proc_every_frame() 매 frame
+    """
+
+    def __init__(self, state_lists: StateLists, state_id: Enum) -> None:
+        self.state_lists: StateLists = state_lists
+        self.state_id: Enum = state_id
+        self._is_run_proc_once: bool = False
+        self.parents_process: Any = None
+        self.state_param_dto: Optional[Any] = None
+
+    def get_state_manager(self) -> Optional[StateManager]:
+        if self.state_lists is None:
+            return None
+        return self.state_lists.get_state_manager()
+
+    def get_state_components(self) -> Optional[StateComponents]:
+        mgr = self.get_state_manager()
+        if mgr is None:
+            return None
+        return mgr.get_parents_state_components()
+
+    def get_parents_process(self) -> Any:
+        components = self.get_state_components()
+        if components is None:
+            return None
+        return components.get_parent_process()
+
+    def _set_parent_process(self) -> None:
+        self.parents_process = self.get_parents_process()
+
+    def base_on_enter(self, state_param_dto: Optional[Any] = None) -> None:
+        self._is_run_proc_once = False
+        self.state_param_dto = state_param_dto
+        self._set_parent_process()
+        self.on_enter()
+
+    def base_on_proc_every_frame(self) -> None:
+        if not self._is_run_proc_once:
+            self.on_proc_once()
+            self._is_run_proc_once = True
+
+        self.on_proc_every_frame()
+
+    @abstractmethod
+    def on_enter(self) -> None: ...
+
+    @abstractmethod
+    def on_leave(self) -> None: ...
+
+    @abstractmethod
+    def on_proc_once(self) -> None: ...
+
+    @abstractmethod
+    def on_proc_every_frame(self) -> None: ...

--- a/src/python_library/state/state_components.py
+++ b/src/python_library/state/state_components.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Optional
+
+from python_library.state.state_lists import StateLists
+from python_library.state.state_manager import StateManager
+
+
+class StateComponents:
+    """
+    process가 보유하는 state machine 컨테이너.
+
+    Reservation 패턴:
+      - change_state(state_id, dto): 다음 frame에 적용할 전환을 예약만
+      - on_change_state(): 예약된 전환을 실제 적용 (frame 안전성)
+      - on_proc_every_frame(): 현재 state의 base_on_proc_every_frame 위임
+    """
+
+    def __init__(
+        self,
+        parent_process: Any,
+        state_lists: StateLists,
+        init_state_id: Optional[Enum] = None,
+    ) -> None:
+        self._parent_process: Any = parent_process
+        self._state_manager: StateManager = StateManager(state_lists, self)
+        self._reserve_state_id: Optional[Enum] = None
+        self._reserve_state_param_dto: Optional[Any] = None
+
+        if init_state_id is not None:
+            self._state_manager.change_state(init_state_id)
+
+    def get_parent_process(self) -> Any:
+        return self._parent_process
+
+    def get_state_manager(self) -> StateManager:
+        return self._state_manager
+
+    def change_state(self, state_id: Enum, state_param_dto: Optional[Any] = None) -> None:
+        """다음 on_change_state() 호출 시 적용될 전환을 예약."""
+        self._reserve_state_id = state_id
+        self._reserve_state_param_dto = state_param_dto
+
+    def on_change_state(self) -> None:
+        """예약된 state 전환을 실제 적용."""
+        if self._reserve_state_id is None:
+            return
+
+        self._state_manager.change_state(self._reserve_state_id, self._reserve_state_param_dto)
+        self._reserve_state_id = None
+        self._reserve_state_param_dto = None
+
+    def on_proc_once(self) -> None:
+        current = self._state_manager.get_current_state()
+        if current is not None:
+            current.on_proc_once()
+
+    def on_proc_every_frame(self) -> None:
+        current = self._state_manager.get_current_state()
+        if current is not None:
+            current.base_on_proc_every_frame()

--- a/src/python_library/state/state_lists.py
+++ b/src/python_library/state/state_lists.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Dict, Optional, TYPE_CHECKING
+
+from python_library.state.state import abState
+
+if TYPE_CHECKING:
+    from python_library.state.state_manager import StateManager
+
+
+class StateLists:
+    """state_id → abState 매핑 + StateManager 백레퍼런스 보유."""
+
+    def __init__(self, state_list: Dict[Enum, abState]) -> None:
+        self._state_list: Dict[Enum, abState] = state_list
+        self._state_manager: Optional[StateManager] = None
+
+    def get_state(self, state_id: Enum) -> abState:
+        return self._state_list[state_id]
+
+    def set_state_manager(self, state_manager: StateManager) -> None:
+        self._state_manager = state_manager
+
+    def get_state_manager(self) -> Optional[StateManager]:
+        return self._state_manager

--- a/src/python_library/state/state_manager.py
+++ b/src/python_library/state/state_manager.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Optional, TYPE_CHECKING
+
+from python_library.state.state import abState
+from python_library.state.state_lists import StateLists
+
+if TYPE_CHECKING:
+    from python_library.state.state_components import StateComponents
+
+
+class StateManager:
+    """현재 state 관리 + 즉시 전환 (OnLeave → BaseOnEnter)."""
+
+    def __init__(
+        self,
+        state_lists: StateLists,
+        parents_state_components: StateComponents,
+    ) -> None:
+        self._parents_state_components: StateComponents = parents_state_components
+        self._current_state_id: Optional[Enum] = None
+        self._state_lists: StateLists = state_lists
+        state_lists.set_state_manager(self)
+
+    def get_parents_state_components(self) -> StateComponents:
+        return self._parents_state_components
+
+    def get_state(self, state_id: Enum) -> abState:
+        return self._state_lists.get_state(state_id)
+
+    def change_state(self, state_id: Enum, state_param_dto: Optional[Any] = None) -> abState:
+        if self._current_state_id is not None:
+            self.get_state(self._current_state_id).on_leave()
+
+        self._current_state_id = state_id
+        next_state = self.get_state(state_id)
+        next_state.base_on_enter(state_param_dto)
+        return next_state
+
+    def get_current_state(self) -> Optional[abState]:
+        if self._current_state_id is None:
+            return None
+        return self._state_lists.get_state(self._current_state_id)
+
+    def get_current_state_id(self) -> Optional[Enum]:
+        return self._current_state_id

--- a/uv.lock
+++ b/uv.lock
@@ -569,7 +569,7 @@ wheels = [
 
 [[package]]
 name = "python-library"
-version = "2.3.1"
+version = "2.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
## Summary
- `src/python_library/state/` 모듈 신설 — Tetris C# 4-layer 패턴 (`abState ← StateLists ← StateManager ← StateComponents ← parent_process`)
- `abState`: parent_process 자동 cache, `base_on_enter(state_param_dto)` / `base_on_proc_every_frame` wrapper, `_is_run_proc_once` flag 자동 관리, abstract lifecycle (on_enter/on_leave/on_proc_once/on_proc_every_frame)
- `StateLists`: state_id → abState 매핑 + StateManager 백레퍼런스
- `StateManager`: `change_state(id, dto)` 즉시 전환 (현재 OnLeave → 다음 BaseOnEnter)
- `StateComponents`: **Reservation 패턴** — `change_state(id, dto)`는 예약만, 다음 frame의 `on_change_state()`가 실제 적용 → frame loop 안전성 확보
- 파일명 snake_case, 클래스명 C# 그대로, state_id 타입은 `Enum`, state_param_dto는 `Optional[Any]`
- 타입 어노테이션은 `from __future__ import annotations` + `TYPE_CHECKING` 패턴 (명시적 따옴표 forward reference 없음)
- 버전 bump 2.3.1 → 2.4.0 (minor) + uv.lock 동기화
- ruff pass, pyright 0 errors, functional smoke test (라이프사이클 + reservation + state_param_dto 전달) 모두 통과

## Related Issue
close #23

## Follow-up
- 머지 후 `uv build`로 wheel 빌드 → data-pipeline의 `libs/`에 복사하여 통합 (data-pipeline Issue #39)