### PR TITLE
[docs] #25 state 패키지 README + tests 추가

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,7 @@ typeCheckingMode = "basic"
 reportOptionalSubscript = "none"
 reportOptionalMemberAccess = "none"
 reportOptionalContextManager = "none"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/src/python_library/state/README.md
+++ b/src/python_library/state/README.md
@@ -1,0 +1,189 @@
+# state
+
+상태 머신(state machine) 4-layer 패키지. 어떤 클래스든 `StateComponents`를 보유시키면 상태 기반 동작을 적용할 수 있다.
+
+## 클래스 구조
+
+```
+abState (ABC)              # 단일 state 추상 클래스 (lifecycle 메서드)
+StateLists                 # state_id → abState 매핑 + StateManager 백레퍼런스
+StateManager               # state 전환 (즉시 적용)
+StateComponents            # 외부 컨테이너 (reservation 패턴)
+```
+
+소유 관계:
+
+```
+parent class
+└── StateComponents
+    └── StateManager
+        └── StateLists
+            └── abState 인스턴스들
+```
+
+---
+
+## 핵심 개념
+
+### Reservation 패턴
+
+`StateComponents.change_state(id, dto)`는 즉시 전환하지 않고 **예약만** 한다.
+다음 frame에서 `on_change_state()`가 호출될 때 비로소 실제 전환이 일어난다.
+이렇게 분리하면 frame 내부에서 state를 바꿔도 현재 frame의 처리가 안전하게 끝난 뒤 적용된다.
+
+### Lifecycle wrapper
+
+`abState`는 두 가지 wrapper 메서드를 제공한다.
+
+- `base_on_enter(state_param_dto)`: `_is_run_proc_once` 리셋 + `parents_process` cache + `state_param_dto` 저장 후 `on_enter()` 호출
+- `base_on_proc_every_frame()`: `on_proc_once()`를 첫 frame에 한 번만 실행 후 매 frame마다 `on_proc_every_frame()` 호출
+
+상속 클래스는 `on_enter` / `on_leave` / `on_proc_once` / `on_proc_every_frame` 4개의 abstract 메서드만 구현한다.
+
+### state_param_dto
+
+state 전환 시 다음 state로 전달되는 payload (`Optional[Any]`).
+새 state는 `self.state_param_dto`로 접근한다.
+
+---
+
+## 사용법
+
+### 1. state 정의
+
+`abState`를 상속하고 lifecycle 메서드를 구현한다.
+
+```python
+from enum import IntEnum
+from python_library.state import abState, StateLists
+
+
+class E_GAME_STATE(IntEnum):
+    IDLE = 0
+    PLAYING = 1
+    PAUSED = 2
+    GAME_OVER = 3
+
+
+class IdleState(abState):
+    def on_enter(self):
+        print(f"[IDLE] enter, dto={self.state_param_dto}")
+
+    def on_leave(self):
+        print("[IDLE] leave")
+
+    def on_proc_once(self):
+        print("[IDLE] first frame")
+
+    def on_proc_every_frame(self):
+        # 매 frame 호출
+        pass
+
+
+class PlayingState(abState):
+    def on_enter(self):
+        # state_param_dto에서 시작 정보 받기
+        score = self.state_param_dto.get("score", 0) if self.state_param_dto else 0
+        print(f"[PLAYING] start with score={score}")
+
+    def on_leave(self): pass
+    def on_proc_once(self): pass
+    def on_proc_every_frame(self):
+        # parents_process(parent class)에 직접 접근 가능
+        if self.parents_process.is_game_over():
+            self.parents_process.state_components.change_state(E_GAME_STATE.GAME_OVER)
+```
+
+### 2. parent class에 StateComponents 부착
+
+```python
+from python_library.state import StateComponents
+
+
+class Game:
+    def __init__(self):
+        # state 인스턴스들 등록
+        state_lists = StateLists({})  # 빈 dict로 시작
+        state_lists._state_list = {
+            E_GAME_STATE.IDLE: IdleState(state_lists, E_GAME_STATE.IDLE),
+            E_GAME_STATE.PLAYING: PlayingState(state_lists, E_GAME_STATE.PLAYING),
+        }
+
+        # StateComponents 부착 — 초기 state로 IDLE 진입
+        self.state_components = StateComponents(
+            parent_process=self,
+            state_lists=state_lists,
+            init_state_id=E_GAME_STATE.IDLE,
+        )
+
+    def is_game_over(self) -> bool:
+        return False  # 게임 로직
+
+    def tick(self):
+        # 매 frame 루프
+        self.state_components.on_change_state()       # 예약된 전환 적용
+        self.state_components.on_proc_every_frame()   # 현재 state 진행
+```
+
+### 3. state 전환
+
+```python
+game = Game()
+game.tick()  # IdleState 첫 frame: on_proc_once + on_proc_every_frame
+
+# 어디서든 전환 예약
+game.state_components.change_state(
+    E_GAME_STATE.PLAYING,
+    state_param_dto={"score": 0, "level": 1},
+)
+
+game.tick()  # 예약 적용 → IdleState.on_leave → PlayingState.base_on_enter → on_proc_once + on_proc_every_frame
+```
+
+---
+
+## API 요약
+
+### `abState`
+
+| 메서드 | 설명 |
+|---|---|
+| `base_on_enter(state_param_dto)` | 진입 wrapper — abstract `on_enter()` 호출 |
+| `base_on_proc_every_frame()` | 매 frame wrapper — 첫 frame `on_proc_once()` + 매 frame `on_proc_every_frame()` |
+| `on_enter()` (abstract) | state 진입 시 1회 호출 |
+| `on_leave()` (abstract) | state 떠날 때 1회 호출 |
+| `on_proc_once()` (abstract) | state 진입 후 첫 frame 1회 호출 |
+| `on_proc_every_frame()` (abstract) | state 활성 동안 매 frame 호출 |
+| `parents_process` | base_on_enter 시 자동 cache되는 parent 참조 |
+| `state_param_dto` | base_on_enter 시 저장된 payload |
+
+### `StateComponents`
+
+| 메서드 | 설명 |
+|---|---|
+| `change_state(state_id, state_param_dto=None)` | 다음 frame에 적용할 전환을 예약만 |
+| `on_change_state()` | 예약된 전환을 실제 적용 (frame 시작 시 호출 권장) |
+| `on_proc_once()` | 현재 state의 `on_proc_once` 위임 |
+| `on_proc_every_frame()` | 현재 state의 `base_on_proc_every_frame` 위임 |
+| `get_state_manager()` | 내부 StateManager 반환 |
+
+### `StateManager`
+
+| 메서드 | 설명 |
+|---|---|
+| `change_state(state_id, dto)` | 즉시 전환 (현재 `on_leave` → 다음 `base_on_enter`) |
+| `get_current_state()` | 현재 state 인스턴스 |
+| `get_current_state_id()` | 현재 state_id (Enum) |
+
+---
+
+## frame loop 구성 예시
+
+```python
+while running:
+    game.state_components.on_change_state()      # 1) 예약된 전환 적용
+    game.state_components.on_proc_every_frame()  # 2) 현재 state 진행
+    time.sleep(1 / 60)                           # 60 FPS
+```
+
+`change_state`는 어느 시점에 호출해도 안전 — 항상 다음 frame 시작 시점에 적용된다.

--- a/tests/test_state/test_state.py
+++ b/tests/test_state/test_state.py
@@ -1,0 +1,106 @@
+from enum import IntEnum
+
+from python_library.state import abState, StateLists
+
+
+class E_TEST(IntEnum):
+    A = 0
+    B = 1
+
+
+class _TrackingState(abState):
+    def __init__(self, state_lists, state_id):
+        super().__init__(state_lists, state_id)
+        self.calls = []
+
+    def on_enter(self):
+        self.calls.append(("on_enter", self.state_param_dto))
+
+    def on_leave(self):
+        self.calls.append(("on_leave",))
+
+    def on_proc_once(self):
+        self.calls.append(("on_proc_once",))
+
+    def on_proc_every_frame(self):
+        self.calls.append(("on_proc_every_frame",))
+
+
+def _build_state_lists():
+    sl = StateLists({})
+    sl._state_list = {E_TEST.A: _TrackingState(sl, E_TEST.A)}
+    return sl
+
+
+def test_base_on_enter_resets_proc_once_flag_and_caches_parent():
+    sl = _build_state_lists()
+    state = sl.get_state(E_TEST.A)
+    state._is_run_proc_once = True
+
+    state.base_on_enter(state_param_dto={"x": 1})
+
+    assert state._is_run_proc_once is False
+    assert state.state_param_dto == {"x": 1}
+    assert state.calls == [("on_enter", {"x": 1})]
+
+
+def test_base_on_enter_default_dto_is_none():
+    sl = _build_state_lists()
+    state = sl.get_state(E_TEST.A)
+
+    state.base_on_enter()
+
+    assert state.state_param_dto is None
+    assert state.calls == [("on_enter", None)]
+
+
+def test_base_on_proc_every_frame_runs_on_proc_once_only_once():
+    sl = _build_state_lists()
+    state = sl.get_state(E_TEST.A)
+
+    state.base_on_proc_every_frame()
+    state.base_on_proc_every_frame()
+    state.base_on_proc_every_frame()
+
+    assert state.calls == [
+        ("on_proc_once",),
+        ("on_proc_every_frame",),
+        ("on_proc_every_frame",),
+        ("on_proc_every_frame",),
+    ]
+
+
+def test_base_on_enter_then_base_on_proc_every_frame_full_lifecycle():
+    sl = _build_state_lists()
+    state = sl.get_state(E_TEST.A)
+
+    state.base_on_enter()
+    state.base_on_proc_every_frame()
+    state.base_on_proc_every_frame()
+
+    assert state.calls == [
+        ("on_enter", None),
+        ("on_proc_once",),
+        ("on_proc_every_frame",),
+        ("on_proc_every_frame",),
+    ]
+
+
+def test_re_enter_resets_proc_once():
+    sl = _build_state_lists()
+    state = sl.get_state(E_TEST.A)
+
+    state.base_on_enter()
+    state.base_on_proc_every_frame()
+
+    state.base_on_enter()
+    state.base_on_proc_every_frame()
+
+    assert state.calls == [
+        ("on_enter", None),
+        ("on_proc_once",),
+        ("on_proc_every_frame",),
+        ("on_enter", None),
+        ("on_proc_once",),
+        ("on_proc_every_frame",),
+    ]

--- a/tests/test_state/test_state_components.py
+++ b/tests/test_state/test_state_components.py
@@ -1,0 +1,124 @@
+from enum import IntEnum
+
+from python_library.state import abState, StateLists, StateComponents
+
+
+class E_TEST(IntEnum):
+    A = 0
+    B = 1
+
+
+class _State(abState):
+    log: list = []
+
+    def on_enter(self):
+        _State.log.append((self.state_id, "on_enter", self.state_param_dto))
+
+    def on_leave(self):
+        _State.log.append((self.state_id, "on_leave"))
+
+    def on_proc_once(self):
+        _State.log.append((self.state_id, "on_proc_once"))
+
+    def on_proc_every_frame(self):
+        _State.log.append((self.state_id, "on_proc_every_frame"))
+
+
+def _build_components(init_state_id=None):
+    _State.log = []
+    sl = StateLists({})
+    sl._state_list = {
+        E_TEST.A: _State(sl, E_TEST.A),
+        E_TEST.B: _State(sl, E_TEST.B),
+    }
+    return StateComponents(parent_process="parent_obj", state_lists=sl, init_state_id=init_state_id)
+
+
+def test_init_state_id_triggers_change_state_immediately():
+    components = _build_components(init_state_id=E_TEST.A)
+
+    assert components.get_state_manager().get_current_state_id() == E_TEST.A
+    assert _State.log == [(E_TEST.A, "on_enter", None)]
+
+
+def test_change_state_only_reserves_does_not_apply():
+    components = _build_components(init_state_id=E_TEST.A)
+    _State.log = []
+
+    components.change_state(E_TEST.B, state_param_dto={"data": 1})
+
+    assert components.get_state_manager().get_current_state_id() == E_TEST.A
+    assert _State.log == []
+
+
+def test_on_change_state_applies_reservation():
+    components = _build_components(init_state_id=E_TEST.A)
+    _State.log = []
+
+    components.change_state(E_TEST.B, state_param_dto={"data": 1})
+    components.on_change_state()
+
+    assert components.get_state_manager().get_current_state_id() == E_TEST.B
+    assert _State.log == [
+        (E_TEST.A, "on_leave"),
+        (E_TEST.B, "on_enter", {"data": 1}),
+    ]
+
+
+def test_on_change_state_without_reservation_is_noop():
+    components = _build_components(init_state_id=E_TEST.A)
+    _State.log = []
+
+    components.on_change_state()
+
+    assert components.get_state_manager().get_current_state_id() == E_TEST.A
+    assert _State.log == []
+
+
+def test_reservation_consumed_after_apply():
+    components = _build_components(init_state_id=E_TEST.A)
+
+    components.change_state(E_TEST.B)
+    components.on_change_state()
+    _State.log = []
+
+    components.on_change_state()
+
+    assert _State.log == []
+
+
+def test_on_proc_every_frame_runs_proc_once_then_every_frame():
+    components = _build_components(init_state_id=E_TEST.A)
+    _State.log = []
+
+    components.on_proc_every_frame()
+    components.on_proc_every_frame()
+
+    assert _State.log == [
+        (E_TEST.A, "on_proc_once"),
+        (E_TEST.A, "on_proc_every_frame"),
+        (E_TEST.A, "on_proc_every_frame"),
+    ]
+
+
+def test_state_param_dto_propagated_to_new_state_on_enter():
+    components = _build_components(init_state_id=E_TEST.A)
+
+    payload = {"x": 42}
+    components.change_state(E_TEST.B, state_param_dto=payload)
+    components.on_change_state()
+
+    state_b = components.get_state_manager().get_state(E_TEST.B)
+    assert state_b.state_param_dto == payload
+
+
+def test_parent_process_cached_in_state_after_enter():
+    components = _build_components(init_state_id=E_TEST.A)
+
+    state_a = components.get_state_manager().get_state(E_TEST.A)
+    assert state_a.parents_process == "parent_obj"
+
+
+def test_get_parent_process_returns_owner():
+    components = _build_components()
+    assert components.get_parent_process() == "parent_obj"

--- a/tests/test_state/test_state_manager.py
+++ b/tests/test_state/test_state_manager.py
@@ -1,0 +1,80 @@
+from enum import IntEnum
+
+from python_library.state import abState, StateLists, StateComponents
+
+
+class E_TEST(IntEnum):
+    A = 0
+    B = 1
+    C = 2
+
+
+class _RecordingState(abState):
+    log: list = []
+
+    def on_enter(self):
+        _RecordingState.log.append((self.state_id, "on_enter", self.state_param_dto))
+
+    def on_leave(self):
+        _RecordingState.log.append((self.state_id, "on_leave"))
+
+    def on_proc_once(self): pass
+    def on_proc_every_frame(self): pass
+
+
+def _build():
+    _RecordingState.log = []
+    sl = StateLists({})
+    sl._state_list = {
+        E_TEST.A: _RecordingState(sl, E_TEST.A),
+        E_TEST.B: _RecordingState(sl, E_TEST.B),
+        E_TEST.C: _RecordingState(sl, E_TEST.C),
+    }
+    components = StateComponents(parent_process="parent", state_lists=sl)
+    return components.get_state_manager()
+
+
+def test_change_state_immediate_calls_on_leave_then_base_on_enter():
+    mgr = _build()
+    mgr.change_state(E_TEST.A)
+    _RecordingState.log = []
+
+    mgr.change_state(E_TEST.B, state_param_dto={"k": "v"})
+
+    assert _RecordingState.log == [
+        (E_TEST.A, "on_leave"),
+        (E_TEST.B, "on_enter", {"k": "v"}),
+    ]
+
+
+def test_first_change_state_no_on_leave():
+    mgr = _build()
+
+    mgr.change_state(E_TEST.A)
+
+    assert _RecordingState.log == [(E_TEST.A, "on_enter", None)]
+
+
+def test_get_current_state_id_tracks_change_state():
+    mgr = _build()
+    assert mgr.get_current_state_id() is None
+
+    mgr.change_state(E_TEST.A)
+    assert mgr.get_current_state_id() == E_TEST.A
+
+    mgr.change_state(E_TEST.B)
+    assert mgr.get_current_state_id() == E_TEST.B
+
+
+def test_get_current_state_returns_instance():
+    mgr = _build()
+    mgr.change_state(E_TEST.C)
+
+    current = mgr.get_current_state()
+    assert current is mgr.get_state(E_TEST.C)
+
+
+def test_state_manager_has_back_reference_from_state_lists():
+    mgr = _build()
+    state = mgr.get_state(E_TEST.A)
+    assert state.state_lists.get_state_manager() is mgr


### PR DESCRIPTION
## Summary
- `src/python_library/state/README.md`: 4-layer 구조도, 핵심 개념(reservation 패턴, lifecycle wrapper, state_param_dto), Game 예시, API 표 — `process`/`thread` README 동일 스타일
- `tests/test_state/test_state.py`: abState 라이프사이클 5건
- `tests/test_state/test_state_manager.py`: StateManager 5건 (change_state immediate, 백레퍼런스 등)
- `tests/test_state/test_state_components.py`: StateComponents 9건 (reservation/state_param_dto/parent cache 등)
- `pyproject.toml`: `[tool.pytest.ini_options]` `testpaths`/`pythonpath` 설정 추가 — 부수효과로 기존 테스트들도 import 가능해짐 (이전엔 `ModuleNotFoundError`)
- pytest **19 passed in 0.16s**

## Related Issue
close #25