### PR TITLE
[refactor] #29 state 패키지 parent_process → owner rename + docstring 제거

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-library"
-version = "2.5.0"
+version = "2.6.0"
 description = "python library"
 requires-python = ">=3.11"
 dependencies = [

--- a/src/python_library/state/README.md
+++ b/src/python_library/state/README.md
@@ -14,7 +14,7 @@ StateComponent             # 외부 컨테이너 (reservation 패턴)
 소유 관계:
 
 ```
-parent class
+owner class
 └── StateComponent
     └── StateManager
         └── StateMap
@@ -35,7 +35,7 @@ parent class
 
 `abState`는 두 가지 wrapper 메서드를 제공한다.
 
-- `base_on_enter(state_param_dto)`: `_is_run_proc_once` 리셋 + `parents_process` cache + `state_param_dto` 저장 후 `on_enter()` 호출
+- `base_on_enter(state_param_dto)`: `_is_run_proc_once` 리셋 + `owner` cache + `state_param_dto` 저장 후 `on_enter()` 호출
 - `base_on_proc_every_frame()`: `on_proc_once()`를 첫 frame에 한 번만 실행 후 매 frame마다 `on_proc_every_frame()` 호출
 
 상속 클래스는 `on_enter` / `on_leave` / `on_proc_once` / `on_proc_every_frame` 4개의 abstract 메서드만 구현한다.
@@ -44,6 +44,16 @@ parent class
 
 state 전환 시 다음 state로 전달되는 payload (`Optional[Any]`).
 새 state는 `self.state_param_dto`로 접근한다.
+
+### owner 타입 narrowing
+
+`abState.owner`의 base 타입은 `Any`. concrete state class에서 attribute annotation으로 narrow하면 IDE/pyright의 자동완성·타입체크 효과를 받을 수 있다.
+
+```python
+class GameState(abState):
+    owner: Game        # ← annotation override로 narrow
+    ...
+```
 
 ---
 
@@ -66,6 +76,8 @@ class E_GAME_STATE(IntEnum):
 
 
 class IdleState(abState):
+    owner: Game
+
     def on_enter(self):
         print(f"[IDLE] enter, dto={self.state_param_dto}")
 
@@ -76,25 +88,24 @@ class IdleState(abState):
         print("[IDLE] first frame")
 
     def on_proc_every_frame(self):
-        # 매 frame 호출
         pass
 
 
 class PlayingState(abState):
+    owner: Game
+
     def on_enter(self):
-        # state_param_dto에서 시작 정보 받기
         score = self.state_param_dto.get("score", 0) if self.state_param_dto else 0
         print(f"[PLAYING] start with score={score}")
 
     def on_leave(self): pass
     def on_proc_once(self): pass
     def on_proc_every_frame(self):
-        # parents_process(parent class)에 직접 접근 가능
-        if self.parents_process.is_game_over():
-            self.parents_process.state_component.change_state(E_GAME_STATE.GAME_OVER)
+        if self.owner.is_game_over():
+            self.owner.state_component.change_state(E_GAME_STATE.GAME_OVER)
 ```
 
-### 2. parent class에 StateComponent 부착
+### 2. owner class에 StateComponent 부착
 
 ```python
 from python_library.state import StateComponent
@@ -102,36 +113,32 @@ from python_library.state import StateComponent
 
 class Game:
     def __init__(self):
-        # state 인스턴스들 등록
-        state_map = StateMap({})  # 빈 dict로 시작
+        state_map = StateMap({})
         state_map._state_map = {
             E_GAME_STATE.IDLE: IdleState(state_map, E_GAME_STATE.IDLE),
             E_GAME_STATE.PLAYING: PlayingState(state_map, E_GAME_STATE.PLAYING),
         }
 
-        # StateComponent 부착 — 초기 state로 IDLE 진입
         self.state_component = StateComponent(
-            parent_process=self,
+            owner=self,
             state_map=state_map,
             init_state_id=E_GAME_STATE.IDLE,
         )
 
     def is_game_over(self) -> bool:
-        return False  # 게임 로직
+        return False
 
     def tick(self):
-        # 매 frame 루프
-        self.state_component.on_change_state()       # 예약된 전환 적용
-        self.state_component.on_proc_every_frame()   # 현재 state 진행
+        self.state_component.on_change_state()
+        self.state_component.on_proc_every_frame()
 ```
 
 ### 3. state 전환
 
 ```python
 game = Game()
-game.tick()  # IdleState 첫 frame: on_proc_once + on_proc_every_frame
+game.tick()
 
-# 어디서든 전환 예약
 game.state_component.change_state(
     E_GAME_STATE.PLAYING,
     state_param_dto={"score": 0, "level": 1},
@@ -154,7 +161,7 @@ game.tick()  # 예약 적용 → IdleState.on_leave → PlayingState.base_on_ent
 | `on_leave()` (abstract) | state 떠날 때 1회 호출 |
 | `on_proc_once()` (abstract) | state 진입 후 첫 frame 1회 호출 |
 | `on_proc_every_frame()` (abstract) | state 활성 동안 매 frame 호출 |
-| `parents_process` | base_on_enter 시 자동 cache되는 parent 참조 |
+| `owner` | base_on_enter 시 자동 cache되는 owner 참조 (`Any`, concrete에서 narrow 권장) |
 | `state_param_dto` | base_on_enter 시 저장된 payload |
 
 ### `StateComponent`
@@ -165,6 +172,7 @@ game.tick()  # 예약 적용 → IdleState.on_leave → PlayingState.base_on_ent
 | `on_change_state()` | 예약된 전환을 실제 적용 (frame 시작 시 호출 권장) |
 | `on_proc_once()` | 현재 state의 `on_proc_once` 위임 |
 | `on_proc_every_frame()` | 현재 state의 `base_on_proc_every_frame` 위임 |
+| `get_owner()` | owner 반환 |
 | `get_state_manager()` | 내부 StateManager 반환 |
 
 ### `StateManager`
@@ -181,9 +189,9 @@ game.tick()  # 예약 적용 → IdleState.on_leave → PlayingState.base_on_ent
 
 ```python
 while running:
-    game.state_component.on_change_state()      # 1) 예약된 전환 적용
-    game.state_component.on_proc_every_frame()  # 2) 현재 state 진행
-    time.sleep(1 / 60)                          # 60 FPS
+    game.state_component.on_change_state()
+    game.state_component.on_proc_every_frame()
+    time.sleep(1 / 60)
 ```
 
 `change_state`는 어느 시점에 호출해도 안전 — 항상 다음 frame 시작 시점에 적용된다.

--- a/src/python_library/state/state.py
+++ b/src/python_library/state/state.py
@@ -11,26 +11,11 @@ if TYPE_CHECKING:
 
 
 class abState(ABC):
-    """
-    Tetris C# abState 동등 클래스.
-
-    Lifecycle:
-      base_on_enter(state_param_dto)
-        -> _is_run_proc_once 리셋
-        -> parents_process cache
-        -> state_param_dto 저장
-        -> on_enter()
-
-      base_on_proc_every_frame()
-        -> on_proc_once() 1회
-        -> on_proc_every_frame() 매 frame
-    """
-
     def __init__(self, state_map: StateMap, state_id: Enum) -> None:
         self.state_map: StateMap = state_map
         self.state_id: Enum = state_id
         self._is_run_proc_once: bool = False
-        self.parents_process: Any = None
+        self.owner: Any = None
         self.state_param_dto: Optional[Any] = None
 
     def get_state_manager(self) -> Optional[StateManager]:
@@ -44,19 +29,19 @@ class abState(ABC):
             return None
         return mgr.get_parent_state_component()
 
-    def get_parents_process(self) -> Any:
+    def get_owner(self) -> Any:
         component = self.get_state_component()
         if component is None:
             return None
-        return component.get_parent_process()
+        return component.get_owner()
 
-    def _set_parent_process(self) -> None:
-        self.parents_process = self.get_parents_process()
+    def _set_owner(self) -> None:
+        self.owner = self.get_owner()
 
     def base_on_enter(self, state_param_dto: Optional[Any] = None) -> None:
         self._is_run_proc_once = False
         self.state_param_dto = state_param_dto
-        self._set_parent_process()
+        self._set_owner()
         self.on_enter()
 
     def base_on_proc_every_frame(self) -> None:

--- a/src/python_library/state/state_component.py
+++ b/src/python_library/state/state_component.py
@@ -8,22 +8,13 @@ from python_library.state.state_map import StateMap
 
 
 class StateComponent:
-    """
-    process가 보유하는 state machine 컨테이너.
-
-    Reservation 패턴:
-      - change_state(state_id, dto): 다음 frame에 적용할 전환을 예약만
-      - on_change_state(): 예약된 전환을 실제 적용 (frame 안전성)
-      - on_proc_every_frame(): 현재 state의 base_on_proc_every_frame 위임
-    """
-
     def __init__(
         self,
-        parent_process: Any,
+        owner: Any,
         state_map: StateMap,
         init_state_id: Optional[Enum] = None,
     ) -> None:
-        self._parent_process: Any = parent_process
+        self._owner: Any = owner
         self._state_manager: StateManager = StateManager(state_map, self)
         self._reserve_state_id: Optional[Enum] = None
         self._reserve_state_param_dto: Optional[Any] = None
@@ -31,19 +22,17 @@ class StateComponent:
         if init_state_id is not None:
             self._state_manager.change_state(init_state_id)
 
-    def get_parent_process(self) -> Any:
-        return self._parent_process
+    def get_owner(self) -> Any:
+        return self._owner
 
     def get_state_manager(self) -> StateManager:
         return self._state_manager
 
     def change_state(self, state_id: Enum, state_param_dto: Optional[Any] = None) -> None:
-        """다음 on_change_state() 호출 시 적용될 전환을 예약."""
         self._reserve_state_id = state_id
         self._reserve_state_param_dto = state_param_dto
 
     def on_change_state(self) -> None:
-        """예약된 state 전환을 실제 적용."""
         if self._reserve_state_id is None:
             return
 

--- a/src/python_library/state/state_manager.py
+++ b/src/python_library/state/state_manager.py
@@ -11,8 +11,6 @@ if TYPE_CHECKING:
 
 
 class StateManager:
-    """현재 state 관리 + 즉시 전환 (OnLeave → BaseOnEnter)."""
-
     def __init__(
         self,
         state_map: StateMap,

--- a/src/python_library/state/state_map.py
+++ b/src/python_library/state/state_map.py
@@ -10,8 +10,6 @@ if TYPE_CHECKING:
 
 
 class StateMap:
-    """state_id → abState 매핑 + StateManager 백레퍼런스 보유."""
-
     def __init__(self, state_map: Dict[Enum, abState]) -> None:
         self._state_map: Dict[Enum, abState] = state_map
         self._state_manager: Optional[StateManager] = None

--- a/tests/test_state/test_state_component.py
+++ b/tests/test_state/test_state_component.py
@@ -31,7 +31,7 @@ def _build_component(init_state_id=None):
         E_TEST.A: _State(sm, E_TEST.A),
         E_TEST.B: _State(sm, E_TEST.B),
     }
-    return StateComponent(parent_process="parent_obj", state_map=sm, init_state_id=init_state_id)
+    return StateComponent(owner="owner_obj", state_map=sm, init_state_id=init_state_id)
 
 
 def test_init_state_id_triggers_change_state_immediately():
@@ -112,13 +112,13 @@ def test_state_param_dto_propagated_to_new_state_on_enter():
     assert state_b.state_param_dto == payload
 
 
-def test_parent_process_cached_in_state_after_enter():
+def test_owner_cached_in_state_after_enter():
     component = _build_component(init_state_id=E_TEST.A)
 
     state_a = component.get_state_manager().get_state(E_TEST.A)
-    assert state_a.parents_process == "parent_obj"
+    assert state_a.owner == "owner_obj"
 
 
-def test_get_parent_process_returns_owner():
+def test_get_owner_returns_owner():
     component = _build_component()
-    assert component.get_parent_process() == "parent_obj"
+    assert component.get_owner() == "owner_obj"

--- a/tests/test_state/test_state_manager.py
+++ b/tests/test_state/test_state_manager.py
@@ -30,7 +30,7 @@ def _build():
         E_TEST.B: _RecordingState(sm, E_TEST.B),
         E_TEST.C: _RecordingState(sm, E_TEST.C),
     }
-    component = StateComponent(parent_process="parent", state_map=sm)
+    component = StateComponent(owner="parent", state_map=sm)
     return component.get_state_manager()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -569,7 +569,7 @@ wheels = [
 
 [[package]]
 name = "python-library"
-version = "2.5.0"
+version = "2.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
## Summary
- `parent_process` / `parents_process` 표현을 `owner`로 일관 rename — state 패키지는 process뿐 아니라 어떤 클래스든 host 가능하므로 더 정확한 어휘
- `get_parent_process` → `get_owner`, `_parent_process` → `_owner`, `_set_parent_process` → `_set_owner`
- 모든 클래스/메서드 docstring 제거 (코드만으로 의도 드러나게)
- README.md: owner 어휘로 갱신 + annotation override 패턴 사용 예시 추가 (concrete state class에서 `owner: Game` 식으로 narrow)
- pyproject.toml 버전 bump 2.5.0 → 2.6.0 (breaking change), uv.lock 동기화
- pytest **19 passed in 0.19s**

## Related Issue
close #29

## Follow-up
- 머지 후 wheel 빌드 + tag v2.6.0 + GitHub Release
- data-pipeline의 Issue #39에서 wheel ref 갱신 + 사용처 (`StateComponent(parent_process=...)` → `owner=...`) rename