### PR TITLE
[refactor] #31 *_shared_queue를 Generic[T]로 일반화

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-library"
-version = "2.6.0"
+version = "2.7.0"
 description = "python library"
 requires-python = ">=3.11"
 dependencies = [

--- a/src/python_library/process/multi_process_manager.py
+++ b/src/python_library/process/multi_process_manager.py
@@ -1,19 +1,21 @@
 from multiprocessing import Manager
 from threading import Lock
 from queue import Queue
-from typing import List, Optional, MutableMapping
+from typing import Generic, List, MutableMapping, Optional, TypeVar
 
 from python_library.job.job import IJob
 from python_library.process.queue_process import IQueueProcess
 from python_library.thread.thread import abThread
 
+T = TypeVar("T")
 
-class MultiProcessManager(abThread):
+
+class MultiProcessManager(abThread, Generic[T]):
     def __init__(self) -> None:
         super().__init__()
         self._manager = Manager()
 
-        self._process_list: List[IQueueProcess] = list()
+        self._process_list: List[IQueueProcess[T]] = list()
 
         self._shared_job_queue: Queue = self._manager.Queue()
         self._shared_job_queue_lock: Lock = self._manager.Lock()
@@ -25,7 +27,7 @@ class MultiProcessManager(abThread):
 
         pass
 
-    def append(self, process: IQueueProcess) -> None:
+    def append(self, process: IQueueProcess[T]) -> None:
         process.set_shared_job_queue(
             self._shared_job_queue, self._shared_job_queue_lock
         )
@@ -60,11 +62,11 @@ class MultiProcessManager(abThread):
 
     ##########################################################################
 
-    def push_shared_queue(self, process_name: str, job: IJob) -> None:
+    def push_shared_queue(self, process_name: str, item: T) -> None:
         with self._shared_queue_lock[process_name]:
-            self._shared_queue[process_name].put(job)
+            self._shared_queue[process_name].put(item)
 
-    def pop_shared_queue(self, process_name: str) -> Optional[IJob]:
+    def pop_shared_queue(self, process_name: str) -> Optional[T]:
         with self._shared_queue_lock[process_name]:
             if self._shared_queue[process_name].empty():
                 return None

--- a/src/python_library/process/queue_process.py
+++ b/src/python_library/process/queue_process.py
@@ -1,13 +1,15 @@
 from queue import Queue
 from threading import Lock
 from abc import abstractmethod
-from typing import Optional, MutableMapping
+from typing import Generic, MutableMapping, Optional, TypeVar
 
 from python_library.job.job import IJob
 from python_library.process.process import IProcess, abProcess
 
+T = TypeVar("T")
 
-class IQueueProcess(IProcess):
+
+class IQueueProcess(IProcess, Generic[T]):
 
     @abstractmethod
     def set_shared_job_queue(self, shared_job_queue: Queue, shared_job_queue_lock: Lock) -> None: ...
@@ -25,16 +27,16 @@ class IQueueProcess(IProcess):
     def set_shared_queue(self, shared_queue: MutableMapping[str, Queue], shared_queue_lock: MutableMapping[str, Lock]) -> None: ...
 
     @abstractmethod
-    def push_shared_queue(self, process_name: str, job: IJob) -> None: ...
+    def push_shared_queue(self, process_name: str, item: T) -> None: ...
 
     @abstractmethod
-    def pop_shared_queue(self, process_name: str) -> Optional[IJob]: ...
+    def pop_shared_queue(self, process_name: str) -> Optional[T]: ...
 
     @abstractmethod
     def size_shared_queue(self, process_name: str) -> int: ...
 
 
-class QueueProcess(abProcess, IQueueProcess):
+class QueueProcess(abProcess, IQueueProcess[T], Generic[T]):
 
     def __init__(self, name: str | None = None) -> None:
         super().__init__(name=name)
@@ -69,12 +71,12 @@ class QueueProcess(abProcess, IQueueProcess):
         self._shared_queue = shared_queue
         self._shared_queue_lock = shared_queue_lock
 
-    def push_shared_queue(self, process_name: str, job: IJob) -> None:
+    def push_shared_queue(self, process_name: str, item: T) -> None:
         assert self._shared_queue_lock is not None
         with self._shared_queue_lock[process_name]:
-            self._shared_queue[process_name].put(job)
+            self._shared_queue[process_name].put(item)
 
-    def pop_shared_queue(self, process_name: str) -> Optional[IJob]:
+    def pop_shared_queue(self, process_name: str) -> Optional[T]:
         assert self._shared_queue_lock is not None
         with self._shared_queue_lock[process_name]:
             if self._shared_queue[process_name].empty():
@@ -87,7 +89,7 @@ class QueueProcess(abProcess, IQueueProcess):
             return self._shared_queue[process_name].qsize()
 
 
-class QueueProcessing(QueueProcess):
+class QueueProcessing(QueueProcess[T], Generic[T]):
     def run(self) -> None:
         try:
             while not self.is_stop():

--- a/tests/test_multi_process/test_generic_queue.py
+++ b/tests/test_multi_process/test_generic_queue.py
@@ -1,0 +1,63 @@
+import time
+from multiprocessing import Manager
+
+from python_library.process.queue_process import QueueProcess
+
+
+class StrEchoProcess(QueueProcess[str]):
+    def action(self) -> None:
+        for _ in range(50):
+            item = self.pop_shared_queue(self.name)
+            if item is None:
+                time.sleep(0.01)
+                continue
+            assert isinstance(item, str)
+            return
+
+
+class IntEchoProcess(QueueProcess[int]):
+    def action(self) -> None:
+        for _ in range(50):
+            item = self.pop_shared_queue(self.name)
+            if item is None:
+                time.sleep(0.01)
+                continue
+            assert isinstance(item, int)
+            return
+
+
+def _wire(process: QueueProcess) -> None:
+    manager = Manager()
+    shared_queue = manager.dict()
+    shared_queue_lock = manager.dict()
+    shared_queue[process.name] = manager.Queue()
+    shared_queue_lock[process.name] = manager.Lock()
+    process.set_shared_queue(shared_queue, shared_queue_lock)
+
+
+def test_str_payload_round_trip():
+    process = StrEchoProcess()
+    _wire(process)
+
+    process.push_shared_queue(process.name, "envelope-1")
+    assert process.size_shared_queue(process.name) == 1
+
+    popped = process.pop_shared_queue(process.name)
+    assert popped == "envelope-1"
+    assert process.size_shared_queue(process.name) == 0
+
+
+def test_int_payload_round_trip():
+    process = IntEchoProcess()
+    _wire(process)
+
+    process.push_shared_queue(process.name, 42)
+    popped = process.pop_shared_queue(process.name)
+    assert popped == 42
+
+
+def test_pop_returns_none_when_empty():
+    process = StrEchoProcess()
+    _wire(process)
+
+    assert process.pop_shared_queue(process.name) is None


### PR DESCRIPTION
## Summary
- IQueueProcess / QueueProcess / QueueProcessing 에 TypeVar T 도입 (default 미지정)
- MultiProcessManager도 Generic[T] 적용
- push_shared_queue / pop_shared_queue의 IJob 고정 시그니처를 T로 변경
- push_shared_job_queue 계열 (IJob 전용)은 그대로 유지
- tests/test_multi_process/test_generic_queue.py 추가 (str/int payload round-trip)
- 버전 2.6.0 → 2.7.0

## BREAKING CHANGE (type-only)
- 기존 `class Foo(QueueProcess):` 사용자는 `class Foo(QueueProcess[IJob])` 등 명시 필요
- runtime 영향 없음, pyright basic mode에서는 무영향
- pyright strict mode에서는 T 명시 안 한 코드가 경고/에러 가능

## Related Issue
close #31