### PR TITLE
[refactor] #33 thread queue를 Generic[T]로 일반화

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-library"
-version = "2.7.0"
+version = "2.8.0"
 description = "python library"
 requires-python = ">=3.11"
 dependencies = [

--- a/src/python_library/job_queue/job_queue.py
+++ b/src/python_library/job_queue/job_queue.py
@@ -1,16 +1,16 @@
 from abc import abstractmethod
-from typing import List, Optional
+from typing import Generic, List, Optional, TypeVar
 
-from python_library.job.job import IJob
+T = TypeVar("T")
 
 
-class IJobQueue:
+class IJobQueue(Generic[T]):
     @abstractmethod
-    def append(self, job: IJob) -> None:
+    def append(self, item: T) -> None:
         pass
 
     @abstractmethod
-    def pop(self) -> Optional[IJob]:
+    def pop(self) -> Optional[T]:
         pass
 
     @abstractmethod
@@ -26,14 +26,14 @@ class IJobQueue:
         pass
 
 
-class JobQueue(IJobQueue):
+class JobQueue(IJobQueue[T], Generic[T]):
     def __init__(self) -> None:
-        self._job_queue: List[IJob] = list()
+        self._job_queue: List[T] = list()
 
-    def append(self, job: IJob) -> None:
-        self._job_queue.append(job)
+    def append(self, item: T) -> None:
+        self._job_queue.append(item)
 
-    def pop(self) -> Optional[IJob]:
+    def pop(self) -> Optional[T]:
         if self.is_empty():
             return None
 

--- a/src/python_library/thread/multi_thread_manager.py
+++ b/src/python_library/thread/multi_thread_manager.py
@@ -1,27 +1,29 @@
 from threading import Lock
-from typing import List, Dict, Optional
+from typing import Dict, Generic, List, Optional, TypeVar
 from abc import abstractmethod
 
+from python_library.job.job import IJob
 from python_library.job_queue.job_queue import IJobQueue, JobQueue
-from python_library.thread.thread import abThread
 from python_library.thread.queue_thread import IQueueThread, QueueThread
 
+T = TypeVar("T")
 
-class MultiThreadManager(QueueThread):
+
+class MultiThreadManager(QueueThread[T], Generic[T]):
     def __init__(self, name: Optional[str] = None) -> None:
         super().__init__(name=name)
 
-        self._threads: List[IQueueThread] = list()
+        self._threads: List[IQueueThread[T]] = list()
 
-        self._shared_job_queue: IJobQueue = JobQueue()
+        self._shared_job_queue: IJobQueue[IJob] = JobQueue[IJob]()
         self._shared_job_queue_lock: Lock = Lock()
 
-        self._shared_queue: Dict[str, IJobQueue] = dict()
+        self._shared_queue: Dict[str, IJobQueue[T]] = dict()
         self._shared_queue_lock: Dict[str, Lock] = dict()
 
         self._allocate_shared_queue()
 
-    def append(self, thread: IQueueThread) -> None:
+    def append(self, thread: IQueueThread[T]) -> None:
         thread.set_shared_job_queue(self._shared_job_queue, self._shared_job_queue_lock)
         thread.set_shared_queue(self._shared_queue, self._shared_queue_lock)
         self._threads.append(thread)

--- a/src/python_library/thread/multi_thread_manager.py
+++ b/src/python_library/thread/multi_thread_manager.py
@@ -2,7 +2,6 @@ from threading import Lock
 from typing import Dict, Generic, List, Optional, TypeVar
 from abc import abstractmethod
 
-from python_library.job.job import IJob
 from python_library.job_queue.job_queue import IJobQueue, JobQueue
 from python_library.thread.queue_thread import IQueueThread, QueueThread
 
@@ -15,7 +14,7 @@ class MultiThreadManager(QueueThread[T], Generic[T]):
 
         self._threads: List[IQueueThread[T]] = list()
 
-        self._shared_job_queue: IJobQueue[IJob] = JobQueue[IJob]()
+        self._shared_job_queue: IJobQueue[T] = JobQueue[T]()
         self._shared_job_queue_lock: Lock = Lock()
 
         self._shared_queue: Dict[str, IJobQueue[T]] = dict()

--- a/src/python_library/thread/queue_thread.py
+++ b/src/python_library/thread/queue_thread.py
@@ -1,16 +1,18 @@
 from abc import abstractmethod
-from typing import Optional, Dict
+from typing import Dict, Generic, Optional, TypeVar
 from threading import Lock
 
 from python_library.job.job import IJob
 from python_library.job_queue.job_queue import IJobQueue, JobQueue
 from python_library.thread.thread import IThread, abThread
 
+T = TypeVar("T")
 
-class IQueueThread(IThread):
+
+class IQueueThread(IThread, Generic[T]):
 
     @abstractmethod
-    def set_shared_job_queue(self, shared_job_queue: IJobQueue, shared_job_queue_lock: Lock) -> None: ...
+    def set_shared_job_queue(self, shared_job_queue: IJobQueue[IJob], shared_job_queue_lock: Lock) -> None: ...
 
     @abstractmethod
     def push_shared_job_queue(self, job: IJob) -> None: ...
@@ -22,33 +24,33 @@ class IQueueThread(IThread):
     def size_shared_job_queue(self) -> int: ...
 
     @abstractmethod
-    def set_shared_queue(self, shared_queue: Dict[str, IJobQueue], shared_queue_lock: Dict[str, Lock]) -> None: ...
+    def set_shared_queue(self, shared_queue: Dict[str, IJobQueue[T]], shared_queue_lock: Dict[str, Lock]) -> None: ...
 
     @abstractmethod
-    def push_shared_queue(self, name: str, job: IJob) -> None: ...
+    def push_shared_queue(self, name: str, item: T) -> None: ...
 
     @abstractmethod
-    def pop_shared_queue(self, name: str) -> Optional[IJob]: ...
+    def pop_shared_queue(self, name: str) -> Optional[T]: ...
 
     @abstractmethod
     def size_shared_queue(self, name: str) -> int: ...
 
 
-class QueueThread(abThread, IQueueThread):
+class QueueThread(abThread, IQueueThread[T], Generic[T]):
     def __init__(self, name: Optional[str] = None) -> None:
         super().__init__(name=name)
-        self._shared_job_queue: Optional[IJobQueue] = None
+        self._shared_job_queue: Optional[IJobQueue[IJob]] = None
         self._shared_job_queue_lock: Optional[Lock] = None
-        self._shared_queue: Optional[Dict[str, IJobQueue]] = None
+        self._shared_queue: Optional[Dict[str, IJobQueue[T]]] = None
         self._shared_queue_lock: Optional[Dict[str, Lock]] = None
 
     def _allocate_shared_queue(self) -> None:
-        self._shared_queue[self.name] = JobQueue()
+        self._shared_queue[self.name] = JobQueue[T]()
         self._shared_queue_lock[self.name] = Lock()
 
     ##########################################################################
 
-    def set_shared_job_queue(self, shared_job_queue: IJobQueue, shared_job_queue_lock: Lock) -> None:
+    def set_shared_job_queue(self, shared_job_queue: IJobQueue[IJob], shared_job_queue_lock: Lock) -> None:
         self._shared_job_queue = shared_job_queue
         self._shared_job_queue_lock = shared_job_queue_lock
 
@@ -68,17 +70,17 @@ class QueueThread(abThread, IQueueThread):
 
     ##########################################################################
 
-    def set_shared_queue(self, shared_queue: Dict[str, IJobQueue], shared_queue_lock: Dict[str, Lock]) -> None:
+    def set_shared_queue(self, shared_queue: Dict[str, IJobQueue[T]], shared_queue_lock: Dict[str, Lock]) -> None:
         self._shared_queue = shared_queue
         self._shared_queue_lock = shared_queue_lock
         self._allocate_shared_queue()
 
-    def push_shared_queue(self, name: str, job: IJob) -> None:
+    def push_shared_queue(self, name: str, item: T) -> None:
         assert self._shared_queue_lock is not None
         with self._shared_queue_lock[name]:
-            self._shared_queue[name].append(job)
+            self._shared_queue[name].append(item)
 
-    def pop_shared_queue(self, name: str) -> Optional[IJob]:
+    def pop_shared_queue(self, name: str) -> Optional[T]:
         assert self._shared_queue_lock is not None
         with self._shared_queue_lock[name]:
             if self._shared_queue[name].is_empty():
@@ -95,7 +97,7 @@ class QueueThread(abThread, IQueueThread):
         pass
 
 
-class QueueThreading(QueueThread):
+class QueueThreading(QueueThread[T], Generic[T]):
     def run(self) -> None:
         try:
             while not self.is_stop():

--- a/src/python_library/thread/queue_thread.py
+++ b/src/python_library/thread/queue_thread.py
@@ -2,7 +2,6 @@ from abc import abstractmethod
 from typing import Dict, Generic, Optional, TypeVar
 from threading import Lock
 
-from python_library.job.job import IJob
 from python_library.job_queue.job_queue import IJobQueue, JobQueue
 from python_library.thread.thread import IThread, abThread
 
@@ -12,13 +11,13 @@ T = TypeVar("T")
 class IQueueThread(IThread, Generic[T]):
 
     @abstractmethod
-    def set_shared_job_queue(self, shared_job_queue: IJobQueue[IJob], shared_job_queue_lock: Lock) -> None: ...
+    def set_shared_job_queue(self, shared_job_queue: IJobQueue[T], shared_job_queue_lock: Lock) -> None: ...
 
     @abstractmethod
-    def push_shared_job_queue(self, job: IJob) -> None: ...
+    def push_shared_job_queue(self, item: T) -> None: ...
 
     @abstractmethod
-    def pop_shared_job_queue(self) -> IJob | None: ...
+    def pop_shared_job_queue(self) -> Optional[T]: ...
 
     @abstractmethod
     def size_shared_job_queue(self) -> int: ...
@@ -39,7 +38,7 @@ class IQueueThread(IThread, Generic[T]):
 class QueueThread(abThread, IQueueThread[T], Generic[T]):
     def __init__(self, name: Optional[str] = None) -> None:
         super().__init__(name=name)
-        self._shared_job_queue: Optional[IJobQueue[IJob]] = None
+        self._shared_job_queue: Optional[IJobQueue[T]] = None
         self._shared_job_queue_lock: Optional[Lock] = None
         self._shared_queue: Optional[Dict[str, IJobQueue[T]]] = None
         self._shared_queue_lock: Optional[Dict[str, Lock]] = None
@@ -50,15 +49,15 @@ class QueueThread(abThread, IQueueThread[T], Generic[T]):
 
     ##########################################################################
 
-    def set_shared_job_queue(self, shared_job_queue: IJobQueue[IJob], shared_job_queue_lock: Lock) -> None:
+    def set_shared_job_queue(self, shared_job_queue: IJobQueue[T], shared_job_queue_lock: Lock) -> None:
         self._shared_job_queue = shared_job_queue
         self._shared_job_queue_lock = shared_job_queue_lock
 
-    def push_shared_job_queue(self, job: IJob) -> None:
+    def push_shared_job_queue(self, item: T) -> None:
         with self._shared_job_queue_lock:
-            self._shared_job_queue.append(job)
+            self._shared_job_queue.append(item)
 
-    def pop_shared_job_queue(self) -> IJob | None:
+    def pop_shared_job_queue(self) -> Optional[T]:
         with self._shared_job_queue_lock:
             if self._shared_job_queue.is_empty():
                 return None

--- a/tests/test_multi_thread/test_thread_generic_queue.py
+++ b/tests/test_multi_thread/test_thread_generic_queue.py
@@ -1,0 +1,77 @@
+import time
+from threading import Lock
+from typing import Dict
+
+from python_library.job_queue.job_queue import IJobQueue, JobQueue
+from python_library.thread.queue_thread import QueueThread
+
+
+class StrEchoThread(QueueThread[str]):
+    def action(self) -> None:
+        for _ in range(50):
+            item = self.pop_shared_queue(self.name)
+            if item is None:
+                time.sleep(0.01)
+                continue
+            assert isinstance(item, str)
+            return
+
+
+class IntEchoThread(QueueThread[int]):
+    def action(self) -> None:
+        for _ in range(50):
+            item = self.pop_shared_queue(self.name)
+            if item is None:
+                time.sleep(0.01)
+                continue
+            assert isinstance(item, int)
+            return
+
+
+def _wire(thread: QueueThread) -> None:
+    shared_queue: Dict[str, IJobQueue] = dict()
+    shared_queue_lock: Dict[str, Lock] = dict()
+    thread.set_shared_queue(shared_queue, shared_queue_lock)
+
+
+def test_str_payload_round_trip():
+    thread = StrEchoThread()
+    _wire(thread)
+
+    thread.push_shared_queue(thread.name, "envelope-1")
+    assert thread.size_shared_queue(thread.name) == 1
+
+    popped = thread.pop_shared_queue(thread.name)
+    assert popped == "envelope-1"
+    assert thread.size_shared_queue(thread.name) == 0
+
+
+def test_int_payload_round_trip():
+    thread = IntEchoThread()
+    _wire(thread)
+
+    thread.push_shared_queue(thread.name, 42)
+    popped = thread.pop_shared_queue(thread.name)
+    assert popped == 42
+
+
+def test_pop_returns_none_when_empty():
+    thread = StrEchoThread()
+    _wire(thread)
+
+    assert thread.pop_shared_queue(thread.name) is None
+
+
+def test_job_queue_generic_str():
+    queue: JobQueue[str] = JobQueue()
+    queue.append("a")
+    queue.append("b")
+
+    assert queue.size() == 2
+    assert queue.is_empty() is False
+
+    popped = queue.pop()
+    assert popped == "b"  # list.pop() is LIFO
+
+    queue.clear()
+    assert queue.is_empty() is True

--- a/tests/test_multi_thread/test_thread_generic_queue.py
+++ b/tests/test_multi_thread/test_thread_generic_queue.py
@@ -75,3 +75,16 @@ def test_job_queue_generic_str():
 
     queue.clear()
     assert queue.is_empty() is True
+
+
+def test_shared_job_queue_generic_payload():
+    thread = StrEchoThread()
+    job_queue: JobQueue[str] = JobQueue()
+    thread.set_shared_job_queue(job_queue, Lock())
+
+    thread.push_shared_job_queue("envelope-job-1")
+    assert thread.size_shared_job_queue() == 1
+
+    popped = thread.pop_shared_job_queue()
+    assert popped == "envelope-job-1"
+    assert thread.size_shared_job_queue() == 0

--- a/uv.lock
+++ b/uv.lock
@@ -569,7 +569,7 @@ wheels = [
 
 [[package]]
 name = "python-library"
-version = "2.6.0"
+version = "2.8.0"
 source = { virtual = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
## Summary
- IJobQueue / JobQueue에 TypeVar T 도입 (process는 stdlib queue.Queue 사용해서 underlying이 Any-typed였지만, thread는 IJobQueue가 underlying이라 함께 generic화 필요)
- IQueueThread / QueueThread / QueueThreading / MultiThreadManager에 Generic[T] 적용
- *_shared_queue뿐 아니라 *_shared_job_queue도 Generic[T]로 일관화 — 두 메서드의 차이는 "single shared (work-stealing)" vs "per-name routing"이지 payload 타입이 아니므로 비대칭 제거
- 버전 2.7.0 → 2.8.0 (runtime 영향 0, type-only soft-breaking)
- tests/test_multi_thread/test_thread_generic_queue.py 추가

## Related Issue
close #33

## Note
process 모듈은 이번 PR에서 손대지 않음. process도 *_shared_job_queue가 IJob 고정인 비대칭이 있으나 별도 Issue로 추적 권장.