### PR TITLE
[refactor] #35 process *_shared_job_queue를 Generic[T]로 일반화

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-library"
-version = "2.8.0"
+version = "2.9.0"
 description = "python library"
 requires-python = ">=3.11"
 dependencies = [

--- a/src/python_library/process/multi_process_manager.py
+++ b/src/python_library/process/multi_process_manager.py
@@ -3,7 +3,6 @@ from threading import Lock
 from queue import Queue
 from typing import Generic, List, MutableMapping, Optional, TypeVar
 
-from python_library.job.job import IJob
 from python_library.process.queue_process import IQueueProcess
 from python_library.thread.thread import abThread
 
@@ -45,11 +44,11 @@ class MultiProcessManager(abThread, Generic[T]):
 
     ##########################################################################
 
-    def push_shared_job_queue(self, job: IJob) -> None:
+    def push_shared_job_queue(self, item: T) -> None:
         with self._shared_job_queue_lock:
-            self._shared_job_queue.put(job)
+            self._shared_job_queue.put(item)
 
-    def pop_shared_job_queue(self) -> IJob | None:
+    def pop_shared_job_queue(self) -> Optional[T]:
         with self._shared_job_queue_lock:
             if self._shared_job_queue.empty():
                 return None

--- a/src/python_library/process/queue_process.py
+++ b/src/python_library/process/queue_process.py
@@ -3,7 +3,6 @@ from threading import Lock
 from abc import abstractmethod
 from typing import Generic, MutableMapping, Optional, TypeVar
 
-from python_library.job.job import IJob
 from python_library.process.process import IProcess, abProcess
 
 T = TypeVar("T")
@@ -15,10 +14,10 @@ class IQueueProcess(IProcess, Generic[T]):
     def set_shared_job_queue(self, shared_job_queue: Queue, shared_job_queue_lock: Lock) -> None: ...
 
     @abstractmethod
-    def push_shared_job_queue(self, job: IJob) -> None: ...
+    def push_shared_job_queue(self, item: T) -> None: ...
 
     @abstractmethod
-    def pop_shared_job_queue(self) -> IJob | None: ...
+    def pop_shared_job_queue(self) -> Optional[T]: ...
 
     @abstractmethod
     def size_shared_job_queue(self) -> int: ...
@@ -51,11 +50,11 @@ class QueueProcess(abProcess, IQueueProcess[T], Generic[T]):
         self._shared_job_queue = shared_job_queue
         self._shared_job_queue_lock = shared_job_queue_lock
 
-    def push_shared_job_queue(self, job: IJob) -> None:
+    def push_shared_job_queue(self, item: T) -> None:
         with self._shared_job_queue_lock:
-            self._shared_job_queue.put(job)
+            self._shared_job_queue.put(item)
 
-    def pop_shared_job_queue(self) -> IJob | None:
+    def pop_shared_job_queue(self) -> Optional[T]:
         with self._shared_job_queue_lock:
             if self._shared_job_queue.empty():
                 return None

--- a/tests/test_multi_process/test_generic_queue.py
+++ b/tests/test_multi_process/test_generic_queue.py
@@ -61,3 +61,16 @@ def test_pop_returns_none_when_empty():
     _wire(process)
 
     assert process.pop_shared_queue(process.name) is None
+
+
+def test_shared_job_queue_generic_payload():
+    process = StrEchoProcess()
+    manager = Manager()
+    process.set_shared_job_queue(manager.Queue(), manager.Lock())
+
+    process.push_shared_job_queue("envelope-job-1")
+    assert process.size_shared_job_queue() == 1
+
+    popped = process.pop_shared_job_queue()
+    assert popped == "envelope-job-1"
+    assert process.size_shared_job_queue() == 0


### PR DESCRIPTION
## Summary
- IQueueProcess / QueueProcess / MultiProcessManager의 push/pop_shared_job_queue 시그니처에서 IJob 제거하고 T 적용
- PR #34(thread) + #31(process *_shared_queue)에 이어 process 모듈 *_shared_job_queue까지 Generic화하여 thread/process 간 비대칭 해소
- 버전 2.8.0 → 2.9.0 (runtime 영향 0, type-only soft-breaking)
- test_shared_job_queue_generic_payload 테스트 추가

## Related Issue
close #35