### PR TITLE
[feat] #37 LocalStorage 구현체 추가

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-library"
-version = "2.9.0"
+version = "2.10.0"
 description = "python library"
 requires-python = ">=3.11"
 dependencies = [

--- a/src/python_library/storage/local/local_storage.py
+++ b/src/python_library/storage/local/local_storage.py
@@ -1,0 +1,48 @@
+from typing import List, Optional
+
+from python_library.storage.storage_file import StorageFile
+from python_library.storage.storage import IStorage
+from python_library.storage.storage_client import IStorageClient
+from python_library.storage.upload_options import UploadOptions
+
+
+class LocalStorage(IStorage):
+    def __init__(self) -> None:
+        self._storage_client: Optional[IStorageClient] = None
+
+    def connect(self) -> None:
+        self._storage_client.connect()
+
+    def disconnect(self) -> None:
+        self._storage_client.disconnect()
+
+    def upload(
+        self, src_path: str, dst_path: str, options: UploadOptions | None = None
+    ) -> None:
+        self._storage_client.upload(src_path, dst_path, options=options)
+
+    def download(self, src_path: str, dst_path: str) -> None:
+        self._storage_client.download(src_path, dst_path)
+
+    def get_file_list(self, path: str) -> List[StorageFile]:
+        return self._storage_client.get_file_list(path)
+
+    def is_exists(self, path: str) -> bool:
+        return self._storage_client.is_exists(path)
+
+    def read(self, path: str) -> bytes:
+        return self._storage_client.read(path)
+
+    def write(
+        self, path: str, data: bytes, options: UploadOptions | None = None
+    ) -> None:
+        self._storage_client.write(path, data, options)
+
+    def copy(self, src_path: str, dst_path: str) -> None:
+        self._storage_client.copy(src_path, dst_path)
+
+    def to_url(self, path: str) -> str:
+        return self._storage_client.to_url(path)
+
+    def set_storage_client(self, storage_client: IStorageClient) -> None:
+        self._storage_client = storage_client

--- a/src/python_library/storage/local/local_storage_client.py
+++ b/src/python_library/storage/local/local_storage_client.py
@@ -1,0 +1,118 @@
+import os
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List
+
+from python_library.storage.storage_file import StorageFile
+from python_library.storage.storage_client import IStorageClient
+from python_library.storage.upload_options import UploadOptions
+
+
+class LocalStorageClient(IStorageClient):
+    SERVICE_NAME = "local"
+    SCHEME = "file://"
+
+    def __init__(self, root_dir: str):
+        if not root_dir:
+            raise ValueError("root_dir is empty")
+
+        self._root_dir: Path = Path(root_dir).resolve()
+
+    def connect(self) -> None:
+        self._root_dir.mkdir(parents=True, exist_ok=True)
+
+    def disconnect(self) -> None:
+        return
+
+    def upload(
+        self, src_path: str, dst_path: str, options: UploadOptions | None = None
+    ) -> None:
+        # local 구현에서는 options(metadata/tagging/multipart 등)는 의미가 없어 무시
+        del options
+
+        dst_abs = self._resolve(dst_path)
+        dst_abs.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(src_path, dst_abs)
+
+    def download(self, src_path: str, dst_path: str) -> None:
+        src_abs = self._resolve(src_path)
+        dst_parent = Path(dst_path).parent
+        if str(dst_parent):
+            dst_parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(src_abs, dst_path)
+
+    def get_file_list(self, path: str) -> List[StorageFile]:
+        files: List[StorageFile] = list()
+
+        prefix_abs = self._resolve(path)
+
+        # S3 list_objects_v2는 prefix가 디렉터리/파일 모두 매칭하므로 동일하게 처리
+        if prefix_abs.is_file():
+            files.append(self._to_storage_file(prefix_abs))
+            return files
+
+        if not prefix_abs.exists():
+            return files
+
+        for root, _dirs, names in os.walk(prefix_abs):
+            root_path = Path(root)
+            for name in names:
+                files.append(self._to_storage_file(root_path / name))
+
+        return files
+
+    def read(self, path: str) -> bytes:
+        abs_path = self._resolve(path)
+        return abs_path.read_bytes()
+
+    def write(
+        self, path: str, data: bytes, options: UploadOptions | None = None
+    ) -> None:
+        del options
+
+        abs_path = self._resolve(path)
+        abs_path.parent.mkdir(parents=True, exist_ok=True)
+        abs_path.write_bytes(data)
+
+    def is_exists(self, path: str) -> bool:
+        return self._resolve(path).exists()
+
+    def copy(self, src_path: str, dst_path: str) -> None:
+        src_abs = self._resolve(src_path)
+        dst_abs = self._resolve(dst_path)
+        dst_abs.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(src_abs, dst_abs)
+
+    def to_url(self, path: str) -> str:
+        """
+        내부 표준 path (/root/key)를 file:// scheme url로 변환.
+        - "/root/key" -> "file://{abs root_dir}/root/key"
+        - 이미 "file://..."면 그대로 반환
+        """
+        if not path:
+            raise ValueError("path is empty")
+
+        if path.startswith(self.SCHEME):
+            return path
+
+        abs_path = self._resolve(path)
+        return f"{self.SCHEME}{abs_path.as_posix()}"
+
+    def _resolve(self, path: str) -> Path:
+        """
+        /root/key 형태의 path를 root_dir 하위 절대 경로로 변환.
+        예 (root_dir=/data):
+            /myroot/foo/bar.txt → /data/myroot/foo/bar.txt
+        """
+        if not path.startswith("/"):
+            raise ValueError(f"Invalid path (must start with '/'): {path}")
+
+        rel = path.lstrip("/")
+        return self._root_dir / rel
+
+    def _to_storage_file(self, abs_path: Path) -> StorageFile:
+        rel = abs_path.relative_to(self._root_dir).as_posix()
+        std_path = f"/{rel}"
+        mtime = datetime.fromtimestamp(abs_path.stat().st_mtime, tz=timezone.utc)
+        return StorageFile(std_path, mtime)

--- a/src/python_library/storage/local/local_storage_factory.py
+++ b/src/python_library/storage/local/local_storage_factory.py
@@ -1,0 +1,14 @@
+from python_library.storage.local.local_storage import LocalStorage
+from python_library.storage.storage import IStorage
+from python_library.storage.storage_factory import IStorageFactory
+from python_library.storage.storage_info_factory import IStorageInfoFactory
+
+
+class LocalStorageFactory(IStorageFactory):
+    def __init__(self, storage_info_factory: IStorageInfoFactory):
+        self._storage_info_factory: IStorageInfoFactory = storage_info_factory
+
+    def create_storage(self) -> IStorage:
+        storage = LocalStorage()
+        storage.set_storage_client(self._storage_info_factory.create_storage_client())
+        return storage

--- a/src/python_library/storage/local/local_storage_info_factory.py
+++ b/src/python_library/storage/local/local_storage_info_factory.py
@@ -1,0 +1,13 @@
+from python_library.storage.local.local_storage_client import LocalStorageClient
+from python_library.storage.storage_client import IStorageClient
+from python_library.storage.storage_info_factory import IStorageInfoFactory
+
+
+class LocalStorageInfoFactory(IStorageInfoFactory):
+    def __init__(self, root_dir: str):
+        super().__init__()
+        self._root_dir: str = root_dir
+
+    def create_storage_client(self) -> IStorageClient:
+        storage_client = LocalStorageClient(self._root_dir)
+        return storage_client

--- a/tests/test_storage/test_local_storage.py
+++ b/tests/test_storage/test_local_storage.py
@@ -1,0 +1,107 @@
+from pathlib import Path
+
+import pytest
+
+from python_library.storage.local.local_storage_factory import LocalStorageFactory
+from python_library.storage.local.local_storage_info_factory import (
+    LocalStorageInfoFactory,
+)
+
+
+@pytest.fixture
+def storage(tmp_path: Path):
+    factory = LocalStorageFactory(LocalStorageInfoFactory(str(tmp_path)))
+    s = factory.create_storage()
+    s.connect()
+    yield s
+    s.disconnect()
+
+
+def test_connect_creates_root_dir(tmp_path: Path):
+    root = tmp_path / "new_root"
+    factory = LocalStorageFactory(LocalStorageInfoFactory(str(root)))
+    s = factory.create_storage()
+    s.connect()
+    assert root.is_dir()
+
+
+def test_write_and_read(storage):
+    storage.write("/myroot/hello.txt", b"hello world")
+    assert storage.read("/myroot/hello.txt") == b"hello world"
+
+
+def test_write_creates_parent_dirs(storage, tmp_path: Path):
+    storage.write("/myroot/sub/nested/file.bin", b"\x00\x01\x02")
+    assert (tmp_path / "myroot" / "sub" / "nested" / "file.bin").is_file()
+
+
+def test_is_exists(storage):
+    assert storage.is_exists("/myroot/missing.txt") is False
+    storage.write("/myroot/found.txt", b"x")
+    assert storage.is_exists("/myroot/found.txt") is True
+
+
+def test_upload(storage, tmp_path: Path):
+    src = tmp_path / "src.txt"
+    src.write_bytes(b"upload-data")
+    storage.upload(str(src), "/myroot/dst.txt")
+    assert storage.read("/myroot/dst.txt") == b"upload-data"
+
+
+def test_download(storage, tmp_path: Path):
+    storage.write("/myroot/remote.txt", b"download-data")
+    dst = tmp_path / "out" / "local.txt"
+    storage.download("/myroot/remote.txt", str(dst))
+    assert dst.read_bytes() == b"download-data"
+
+
+def test_copy(storage):
+    storage.write("/myroot/a.txt", b"copy-me")
+    storage.copy("/myroot/a.txt", "/myroot/sub/b.txt")
+    assert storage.read("/myroot/sub/b.txt") == b"copy-me"
+    # 원본은 유지
+    assert storage.is_exists("/myroot/a.txt") is True
+
+
+def test_get_file_list(storage):
+    storage.write("/myroot/a.txt", b"1")
+    storage.write("/myroot/sub/b.txt", b"2")
+    storage.write("/myroot/sub/c.txt", b"3")
+
+    files = storage.get_file_list("/myroot")
+    paths = sorted(f.get_file_path() for f in files)
+    assert paths == ["/myroot/a.txt", "/myroot/sub/b.txt", "/myroot/sub/c.txt"]
+
+
+def test_get_file_list_with_prefix(storage):
+    storage.write("/myroot/sub/b.txt", b"2")
+    storage.write("/myroot/other/x.txt", b"3")
+
+    files = storage.get_file_list("/myroot/sub")
+    paths = [f.get_file_path() for f in files]
+    assert paths == ["/myroot/sub/b.txt"]
+
+
+def test_get_file_list_missing_returns_empty(storage):
+    assert storage.get_file_list("/myroot/no_such_dir") == []
+
+
+def test_to_url(storage, tmp_path: Path):
+    url = storage.to_url("/myroot/file.txt")
+    expected = f"file://{tmp_path.resolve().as_posix()}/myroot/file.txt"
+    assert url == expected
+
+
+def test_to_url_passthrough(storage):
+    already = "file:///already/abs.txt"
+    assert storage.to_url(already) == already
+
+
+def test_invalid_path_rejected(storage):
+    with pytest.raises(ValueError):
+        storage.read("no-leading-slash.txt")
+
+
+def test_empty_root_dir_rejected():
+    with pytest.raises(ValueError):
+        LocalStorageInfoFactory("").create_storage_client()

--- a/uv.lock
+++ b/uv.lock
@@ -569,7 +569,7 @@ wheels = [
 
 [[package]]
 name = "python-library"
-version = "2.8.0"
+version = "2.10.0"
 source = { virtual = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
## Summary
- storage/local/ 하위에 LocalStorage / LocalStorageClient / LocalStorageFactory / LocalStorageInfoFactory 4개 파일 추가
- 경로 형식 `/root/key` S3와 통일, `LocalStorageInfoFactory(root_dir)`가 실제 mount-point 주입
- `IStorage` / `IStorageClient` 인터페이스 전 메서드 구현 + `to_url`은 `file://` scheme
- tmp_path fixture 기반 단위 테스트 14건 추가
- pyproject 버전 `2.10.0`으로 bump

## Related Issue
close #37