### PR TITLE
[refactor] #39 LocalStorage에서 root_dir 제거하여 S3와 API 대칭화

### DIFF
--- a/src/python_library/storage/local/local_storage_client.py
+++ b/src/python_library/storage/local/local_storage_client.py
@@ -13,14 +13,11 @@ class LocalStorageClient(IStorageClient):
     SERVICE_NAME = "local"
     SCHEME = "file://"
 
-    def __init__(self, root_dir: str):
-        if not root_dir:
-            raise ValueError("root_dir is empty")
-
-        self._root_dir: Path = Path(root_dir).resolve()
+    def __init__(self):
+        pass
 
     def connect(self) -> None:
-        self._root_dir.mkdir(parents=True, exist_ok=True)
+        return
 
     def disconnect(self) -> None:
         return
@@ -31,31 +28,31 @@ class LocalStorageClient(IStorageClient):
         # local 구현에서는 options(metadata/tagging/multipart 등)는 의미가 없어 무시
         del options
 
-        dst_abs = self._resolve(dst_path)
-        dst_abs.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copyfile(src_path, dst_abs)
+        dst = self._resolve(dst_path)
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(src_path, dst)
 
     def download(self, src_path: str, dst_path: str) -> None:
-        src_abs = self._resolve(src_path)
+        src = self._resolve(src_path)
         dst_parent = Path(dst_path).parent
         if str(dst_parent):
             dst_parent.mkdir(parents=True, exist_ok=True)
-        shutil.copyfile(src_abs, dst_path)
+        shutil.copyfile(src, dst_path)
 
     def get_file_list(self, path: str) -> List[StorageFile]:
         files: List[StorageFile] = list()
 
-        prefix_abs = self._resolve(path)
+        prefix = self._resolve(path)
 
         # S3 list_objects_v2는 prefix가 디렉터리/파일 모두 매칭하므로 동일하게 처리
-        if prefix_abs.is_file():
-            files.append(self._to_storage_file(prefix_abs))
+        if prefix.is_file():
+            files.append(self._to_storage_file(prefix))
             return files
 
-        if not prefix_abs.exists():
+        if not prefix.exists():
             return files
 
-        for root, _dirs, names in os.walk(prefix_abs):
+        for root, _dirs, names in os.walk(prefix):
             root_path = Path(root)
             for name in names:
                 files.append(self._to_storage_file(root_path / name))
@@ -63,8 +60,7 @@ class LocalStorageClient(IStorageClient):
         return files
 
     def read(self, path: str) -> bytes:
-        abs_path = self._resolve(path)
-        return abs_path.read_bytes()
+        return self._resolve(path).read_bytes()
 
     def write(
         self, path: str, data: bytes, options: UploadOptions | None = None
@@ -79,15 +75,15 @@ class LocalStorageClient(IStorageClient):
         return self._resolve(path).exists()
 
     def copy(self, src_path: str, dst_path: str) -> None:
-        src_abs = self._resolve(src_path)
-        dst_abs = self._resolve(dst_path)
-        dst_abs.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copyfile(src_abs, dst_abs)
+        src = self._resolve(src_path)
+        dst = self._resolve(dst_path)
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(src, dst)
 
     def to_url(self, path: str) -> str:
         """
-        내부 표준 path (/root/key)를 file:// scheme url로 변환.
-        - "/root/key" -> "file://{abs root_dir}/root/key"
+        절대 fs 경로를 file:// scheme url로 변환.
+        - "/abs/path" -> "file:///abs/path"
         - 이미 "file://..."면 그대로 반환
         """
         if not path:
@@ -96,23 +92,17 @@ class LocalStorageClient(IStorageClient):
         if path.startswith(self.SCHEME):
             return path
 
-        abs_path = self._resolve(path)
-        return f"{self.SCHEME}{abs_path.as_posix()}"
-
-    def _resolve(self, path: str) -> Path:
-        """
-        /root/key 형태의 path를 root_dir 하위 절대 경로로 변환.
-        예 (root_dir=/data):
-            /myroot/foo/bar.txt → /data/myroot/foo/bar.txt
-        """
         if not path.startswith("/"):
             raise ValueError(f"Invalid path (must start with '/'): {path}")
 
-        rel = path.lstrip("/")
-        return self._root_dir / rel
+        return f"{self.SCHEME}{path}"
+
+    def _resolve(self, path: str) -> Path:
+        if not path.startswith("/"):
+            raise ValueError(f"Invalid path (must start with '/'): {path}")
+        return Path(path)
 
     def _to_storage_file(self, abs_path: Path) -> StorageFile:
-        rel = abs_path.relative_to(self._root_dir).as_posix()
-        std_path = f"/{rel}"
+        std_path = abs_path.as_posix()
         mtime = datetime.fromtimestamp(abs_path.stat().st_mtime, tz=timezone.utc)
         return StorageFile(std_path, mtime)

--- a/src/python_library/storage/local/local_storage_info_factory.py
+++ b/src/python_library/storage/local/local_storage_info_factory.py
@@ -4,10 +4,9 @@ from python_library.storage.storage_info_factory import IStorageInfoFactory
 
 
 class LocalStorageInfoFactory(IStorageInfoFactory):
-    def __init__(self, root_dir: str):
+    def __init__(self):
         super().__init__()
-        self._root_dir: str = root_dir
 
     def create_storage_client(self) -> IStorageClient:
-        storage_client = LocalStorageClient(self._root_dir)
+        storage_client = LocalStorageClient()
         return storage_client

--- a/tests/test_storage/test_local_storage.py
+++ b/tests/test_storage/test_local_storage.py
@@ -10,86 +10,87 @@ from python_library.storage.local.local_storage_info_factory import (
 
 @pytest.fixture
 def storage(tmp_path: Path):
-    factory = LocalStorageFactory(LocalStorageInfoFactory(str(tmp_path)))
+    factory = LocalStorageFactory(LocalStorageInfoFactory())
     s = factory.create_storage()
     s.connect()
     yield s
     s.disconnect()
 
 
-def test_connect_creates_root_dir(tmp_path: Path):
-    root = tmp_path / "new_root"
-    factory = LocalStorageFactory(LocalStorageInfoFactory(str(root)))
-    s = factory.create_storage()
-    s.connect()
-    assert root.is_dir()
+@pytest.fixture
+def base(tmp_path: Path) -> str:
+    return tmp_path.as_posix()
 
 
-def test_write_and_read(storage):
-    storage.write("/myroot/hello.txt", b"hello world")
-    assert storage.read("/myroot/hello.txt") == b"hello world"
+def test_write_and_read(storage, base):
+    p = f"{base}/myroot/hello.txt"
+    storage.write(p, b"hello world")
+    assert storage.read(p) == b"hello world"
 
 
-def test_write_creates_parent_dirs(storage, tmp_path: Path):
-    storage.write("/myroot/sub/nested/file.bin", b"\x00\x01\x02")
+def test_write_creates_parent_dirs(storage, base, tmp_path: Path):
+    p = f"{base}/myroot/sub/nested/file.bin"
+    storage.write(p, b"\x00\x01\x02")
     assert (tmp_path / "myroot" / "sub" / "nested" / "file.bin").is_file()
 
 
-def test_is_exists(storage):
-    assert storage.is_exists("/myroot/missing.txt") is False
-    storage.write("/myroot/found.txt", b"x")
-    assert storage.is_exists("/myroot/found.txt") is True
+def test_is_exists(storage, base):
+    assert storage.is_exists(f"{base}/myroot/missing.txt") is False
+    storage.write(f"{base}/myroot/found.txt", b"x")
+    assert storage.is_exists(f"{base}/myroot/found.txt") is True
 
 
-def test_upload(storage, tmp_path: Path):
+def test_upload(storage, base, tmp_path: Path):
     src = tmp_path / "src.txt"
     src.write_bytes(b"upload-data")
-    storage.upload(str(src), "/myroot/dst.txt")
-    assert storage.read("/myroot/dst.txt") == b"upload-data"
+    storage.upload(str(src), f"{base}/myroot/dst.txt")
+    assert storage.read(f"{base}/myroot/dst.txt") == b"upload-data"
 
 
-def test_download(storage, tmp_path: Path):
-    storage.write("/myroot/remote.txt", b"download-data")
+def test_download(storage, base, tmp_path: Path):
+    storage.write(f"{base}/myroot/remote.txt", b"download-data")
     dst = tmp_path / "out" / "local.txt"
-    storage.download("/myroot/remote.txt", str(dst))
+    storage.download(f"{base}/myroot/remote.txt", str(dst))
     assert dst.read_bytes() == b"download-data"
 
 
-def test_copy(storage):
-    storage.write("/myroot/a.txt", b"copy-me")
-    storage.copy("/myroot/a.txt", "/myroot/sub/b.txt")
-    assert storage.read("/myroot/sub/b.txt") == b"copy-me"
-    # 원본은 유지
-    assert storage.is_exists("/myroot/a.txt") is True
+def test_copy(storage, base):
+    storage.write(f"{base}/myroot/a.txt", b"copy-me")
+    storage.copy(f"{base}/myroot/a.txt", f"{base}/myroot/sub/b.txt")
+    assert storage.read(f"{base}/myroot/sub/b.txt") == b"copy-me"
+    assert storage.is_exists(f"{base}/myroot/a.txt") is True
 
 
-def test_get_file_list(storage):
-    storage.write("/myroot/a.txt", b"1")
-    storage.write("/myroot/sub/b.txt", b"2")
-    storage.write("/myroot/sub/c.txt", b"3")
+def test_get_file_list(storage, base):
+    storage.write(f"{base}/myroot/a.txt", b"1")
+    storage.write(f"{base}/myroot/sub/b.txt", b"2")
+    storage.write(f"{base}/myroot/sub/c.txt", b"3")
 
-    files = storage.get_file_list("/myroot")
+    files = storage.get_file_list(f"{base}/myroot")
     paths = sorted(f.get_file_path() for f in files)
-    assert paths == ["/myroot/a.txt", "/myroot/sub/b.txt", "/myroot/sub/c.txt"]
+    assert paths == [
+        f"{base}/myroot/a.txt",
+        f"{base}/myroot/sub/b.txt",
+        f"{base}/myroot/sub/c.txt",
+    ]
 
 
-def test_get_file_list_with_prefix(storage):
-    storage.write("/myroot/sub/b.txt", b"2")
-    storage.write("/myroot/other/x.txt", b"3")
+def test_get_file_list_with_prefix(storage, base):
+    storage.write(f"{base}/myroot/sub/b.txt", b"2")
+    storage.write(f"{base}/myroot/other/x.txt", b"3")
 
-    files = storage.get_file_list("/myroot/sub")
+    files = storage.get_file_list(f"{base}/myroot/sub")
     paths = [f.get_file_path() for f in files]
-    assert paths == ["/myroot/sub/b.txt"]
+    assert paths == [f"{base}/myroot/sub/b.txt"]
 
 
-def test_get_file_list_missing_returns_empty(storage):
-    assert storage.get_file_list("/myroot/no_such_dir") == []
+def test_get_file_list_missing_returns_empty(storage, base):
+    assert storage.get_file_list(f"{base}/myroot/no_such_dir") == []
 
 
-def test_to_url(storage, tmp_path: Path):
-    url = storage.to_url("/myroot/file.txt")
-    expected = f"file://{tmp_path.resolve().as_posix()}/myroot/file.txt"
-    assert url == expected
+def test_to_url(storage, base):
+    p = f"{base}/myroot/file.txt"
+    assert storage.to_url(p) == f"file://{p}"
 
 
 def test_to_url_passthrough(storage):
@@ -100,8 +101,3 @@ def test_to_url_passthrough(storage):
 def test_invalid_path_rejected(storage):
     with pytest.raises(ValueError):
         storage.read("no-leading-slash.txt")
-
-
-def test_empty_root_dir_rejected():
-    with pytest.raises(ValueError):
-        LocalStorageInfoFactory("").create_storage_client()


### PR DESCRIPTION
## Summary
- LocalStorageInfoFactory/LocalStorageClient에서 root_dir 인자 제거
- caller가 fs 절대경로를 path로 직접 전달하는 self-contained path 규약으로 변경 (S3 구현과 대칭)
- LocalStorageClient의 path 합성/relative 변환 로직 제거, `_resolve()`는 fs 절대경로 검증만 수행
- `_to_storage_file()`이 abs path 그대로 반환 (S3가 `/bucket/key` 그대로 반환하는 것과 대칭)
- test_local_storage.py를 새 API에 맞게 갱신, root_dir 의존 테스트 제거

## Related Issues
- close #39