### PR TITLE
[chore] #41 pyproject 2.10.0 → 2.11.0 bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-library"
-version = "2.10.0"
+version = "2.11.0"
 description = "python library"
 requires-python = ">=3.11"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -569,7 +569,7 @@ wheels = [
 
 [[package]]
 name = "python-library"
-version = "2.10.0"
+version = "2.11.0"
 source = { virtual = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
## Summary
- pyproject.toml version 2.10.0 → 2.11.0
- uv.lock 동기화
- #39 LocalStorage root_dir 제거(API breaking) 변경을 새 minor 버전으로 release

## Related Issues
- close #41