### PR TITLE
[refactor] #43 MultiProcess/MultiThreadManager.action()을 기본 no-op으로 통일

### DIFF
--- a/src/python_library/process/multi_process_manager.py
+++ b/src/python_library/process/multi_process_manager.py
@@ -92,7 +92,6 @@ class MultiProcessManager(abThread, Generic[T]):
             raise e
 
     def action(self) -> None:
-        print("MultiProcessManager action()")
         pass
 
     def stop(self):

--- a/src/python_library/thread/multi_thread_manager.py
+++ b/src/python_library/thread/multi_thread_manager.py
@@ -1,6 +1,5 @@
 from threading import Lock
 from typing import Dict, Generic, List, Optional, TypeVar
-from abc import abstractmethod
 
 from python_library.job_queue.job_queue import IJobQueue, JobQueue
 from python_library.thread.queue_thread import IQueueThread, QueueThread
@@ -40,7 +39,6 @@ class MultiThreadManager(QueueThread[T], Generic[T]):
         except Exception as e:
             raise e
 
-    @abstractmethod
     def action(self) -> None:
         pass
 


### PR DESCRIPTION
## Summary
- `MultiProcessManager.action()`에서 디버그용 `print` 제거
- `MultiThreadManager.action()`에서 `@abstractmethod` 제거 (미사용 `from abc import abstractmethod` import도 정리)
- 두 매니저 모두 직접 인스턴스화 가능, 필요 시 서브클래스에서 `action()` 오버라이드하는 패턴으로 통일

## Related Issues
- close #43