### PR TITLE
[chore] #45 pyproject 2.11.0 → 2.11.1 bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-library"
-version = "2.11.0"
+version = "2.11.1"
 description = "python library"
 requires-python = ">=3.11"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -569,7 +569,7 @@ wheels = [
 
 [[package]]
 name = "python-library"
-version = "2.11.0"
+version = "2.11.1"
 source = { virtual = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
## Summary
- `pyproject.toml` version 2.11.0 → 2.11.1
- `uv.lock` 동기화
- PR #44 (close #43)에서 `MultiProcess/MultiThreadManager.action()`을 기본 no-op으로 통일한 변경을 새 PATCH 버전으로 release

## Related Issues
- close #45