### PR TITLE
[fix] #47 S3 is_exists 가 prefix 도 인식하도록 fallback 추가

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-library"
-version = "2.11.1"
+version = "2.11.2"
 description = "python library"
 requires-python = ">=3.11"
 dependencies = [

--- a/src/python_library/storage/s3/s3_storage_client.py
+++ b/src/python_library/storage/s3/s3_storage_client.py
@@ -138,16 +138,16 @@ class S3StorageClient(IStorageClient):
             raise e
 
     def is_exists(self, path: str) -> bool:
+        bucket, key = self._parse_s3_path(path)
         try:
-            bucket, key = self._parse_s3_path(path)
-
             self._client.head_object(Bucket=bucket, Key=key)
             return True
         except ClientError as e:
-            if e.response["Error"]["Code"] == "404":
-                return False
-            else:
+            if e.response["Error"]["Code"] != "404":
                 raise
+
+        response = self._client.list_objects_v2(Bucket=bucket, Prefix=key, MaxKeys=1)
+        return response.get("KeyCount", 0) > 0
 
     def copy(self, src_path: str, dst_path: str) -> None:
         try:

--- a/uv.lock
+++ b/uv.lock
@@ -569,7 +569,7 @@ wheels = [
 
 [[package]]
 name = "python-library"
-version = "2.11.1"
+version = "2.11.2"
 source = { virtual = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
## Summary
\`S3StorageClient.is_exists(path)\` 가 \`head_object\` 단일 호출이라 prefix path (S3 에서 폴더 보이는 자리) 가 항상 404 → False. LocalStorage 의 \`os.path.exists\` 와 \`IStorage.is_exists\` 인터페이스 의미가 어긋남.

수정: head_object 가 404 면 \`list_objects_v2(Prefix=key, MaxKeys=1)\` fallback. prefix 아래 객체 1개라도 있으면 True. 기존 object 존재 케이스는 head_object 가 그대로 True 반환 → backward-compatible.

SemVer PATCH: \`v2.11.1\` → \`v2.11.2\`.

## Test plan
- [x] ruff / pyright pass
- [ ] sensor-data-normalization 에서 \`_collect_file_list\` 가 S3 RAW prefix 를 정상 인식해 cycle 진행 (PR 머지 + tag push 후 normalization dep bump PR 에서 확인)

## Related Issues
- close #47