### PR TITLE
[feat] #49 S3StorageClient에 STS 임시 자격증명 옵션 추가

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-library"
-version = "2.11.2"
+version = "2.12.0"
 description = "python library"
 requires-python = ">=3.11"
 dependencies = [

--- a/src/python_library/storage/s3/s3_storage_client.py
+++ b/src/python_library/storage/s3/s3_storage_client.py
@@ -16,8 +16,16 @@ class S3StorageClient(IStorageClient):
     SERVICE_NAME = "s3"
     SCHEME = "s3://"
 
-    def __init__(self):
+    def __init__(
+        self,
+        access_key: Optional[str] = None,
+        secret_key: Optional[str] = None,
+        session_token: Optional[str] = None,
+    ) -> None:
         self._client: Optional[BaseClient] = None
+        self._access_key = access_key
+        self._secret_key = secret_key
+        self._session_token = session_token
 
     def connect(self) -> None:
         try:
@@ -29,10 +37,17 @@ class S3StorageClient(IStorageClient):
                 tcp_keepalive=True,
             )
 
-            self._client = boto3.client(
-                service_name=S3StorageClient.SERVICE_NAME,
-                config=config,
-            )
+            kwargs: dict = {
+                "service_name": S3StorageClient.SERVICE_NAME,
+                "config": config,
+            }
+
+            if self._access_key:
+                kwargs["aws_access_key_id"] = self._access_key
+                kwargs["aws_secret_access_key"] = self._secret_key
+                kwargs["aws_session_token"] = self._session_token
+
+            self._client = boto3.client(**kwargs)
         except Exception as e:
             raise e
         pass

--- a/src/python_library/storage/s3/s3_storage_info_factory.py
+++ b/src/python_library/storage/s3/s3_storage_info_factory.py
@@ -1,12 +1,25 @@
+from typing import Optional
+
 from python_library.storage.s3.s3_storage_client import S3StorageClient
 from python_library.storage.storage_client import IStorageClient
 from python_library.storage.storage_info_factory import IStorageInfoFactory
 
 
 class S3StorageInfoFactory(IStorageInfoFactory):
-    def __init__(self):
+    def __init__(
+        self,
+        access_key: Optional[str] = None,
+        secret_key: Optional[str] = None,
+        session_token: Optional[str] = None,
+    ) -> None:
         super().__init__()
+        self._access_key = access_key
+        self._secret_key = secret_key
+        self._session_token = session_token
 
     def create_storage_client(self) -> IStorageClient:
-        storage_client = S3StorageClient()
-        return storage_client
+        return S3StorageClient(
+            access_key=self._access_key,
+            secret_key=self._secret_key,
+            session_token=self._session_token,
+        )

--- a/tests/test_storage/test_s3_storage_client.py
+++ b/tests/test_storage/test_s3_storage_client.py
@@ -1,0 +1,49 @@
+from unittest.mock import patch
+
+from python_library.storage.s3.s3_storage_client import S3StorageClient
+from python_library.storage.s3.s3_storage_factory import S3StorageFactory
+from python_library.storage.s3.s3_storage_info_factory import S3StorageInfoFactory
+
+
+@patch("python_library.storage.s3.s3_storage_client.boto3")
+def test_connect_without_credentials(mock_boto3):
+    client = S3StorageClient()
+    client.connect()
+
+    call_kwargs = mock_boto3.client.call_args.kwargs
+    assert "aws_access_key_id" not in call_kwargs
+    assert "aws_secret_access_key" not in call_kwargs
+    assert "aws_session_token" not in call_kwargs
+
+
+@patch("python_library.storage.s3.s3_storage_client.boto3")
+def test_connect_with_sts_credentials(mock_boto3):
+    client = S3StorageClient(
+        access_key="ASIA_TEST_KEY",
+        secret_key="test_secret",
+        session_token="test_token",
+    )
+    client.connect()
+
+    call_kwargs = mock_boto3.client.call_args.kwargs
+    assert call_kwargs["aws_access_key_id"] == "ASIA_TEST_KEY"
+    assert call_kwargs["aws_secret_access_key"] == "test_secret"
+    assert call_kwargs["aws_session_token"] == "test_token"
+
+
+@patch("python_library.storage.s3.s3_storage_client.boto3")
+def test_factory_creates_client_with_sts_credentials(mock_boto3):
+    factory = S3StorageFactory(
+        S3StorageInfoFactory(
+            access_key="ASIA_TEST_KEY",
+            secret_key="test_secret",
+            session_token="test_token",
+        )
+    )
+    storage = factory.create_storage()
+    storage.connect()
+
+    call_kwargs = mock_boto3.client.call_args.kwargs
+    assert call_kwargs["aws_access_key_id"] == "ASIA_TEST_KEY"
+    assert call_kwargs["aws_secret_access_key"] == "test_secret"
+    assert call_kwargs["aws_session_token"] == "test_token"

--- a/uv.lock
+++ b/uv.lock
@@ -569,7 +569,7 @@ wheels = [
 
 [[package]]
 name = "python-library"
-version = "2.11.2"
+version = "2.12.0"
 source = { virtual = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
## Summary
- S3StorageClient.__init__에 access_key/secret_key/session_token 옵셔널 파라미터 추가
- connect() 시 credentials가 주어지면 해당 값으로 boto3 client 생성, 없으면 기존 방식(환경변수/~/.aws) 유지
- S3StorageInfoFactory도 동일 파라미터를 받아 S3StorageClient에 전달 (하위 호환 유지)
- 자격증명 없음/있음/팩토리 경유 테스트 3건 추가
- 버전 2.11.2 → 2.12.0 bump 및 uv.lock 갱신

## Related Issues
- close #49