### PR TITLE
[refactor] #53 thread/process on_exception 예외 처리 훅 도입

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-library"
-version = "2.12.0"
+version = "2.13.0"
 description = "python library"
 requires-python = ">=3.11"
 dependencies = [

--- a/src/python_library/process/README.md
+++ b/src/python_library/process/README.md
@@ -112,3 +112,19 @@ while True:
 
 `stop()` 호출 시 내부 `multiprocessing.Event`를 set한다.
 `is_stop()`, `is_running()`으로 외부에서 상태를 확인할 수 있다.
+
+### 예외 처리 (on_exception)
+
+`action()` 예외는 `run()`이 잡아 `on_exception(e)`를 호출한다. **기본은 예외를 다시
+던진다(fail-loud)** — 단발형(`abProcess`)은 종료, 루프형(`abProcessing`/`QueueProcessing`)은
+루프가 끝난다. resilient 워커가 필요하면 `on_exception`을 오버라이드해 예외를 삼긴다.
+
+```python
+class MyProcess(abProcess):
+    def on_exception(self, e: Exception) -> None:
+        logger.error("process %s failed, continuing: %s", self.name, e)  # 삼키고 계속
+```
+
+> 주의: `on_exception`은 **자식 프로세스 안에서** 실행된다. 메모리가 분리되므로
+> 부모 프로세스의 상태를 직접 바꿀 수 없다. 부모가 실패를 인지해야 한다면
+> `multiprocessing.Queue`(공유 큐)에 실패 정보를 push하는 식으로 전달한다.

--- a/src/python_library/process/multi_process_manager.py
+++ b/src/python_library/process/multi_process_manager.py
@@ -89,7 +89,7 @@ class MultiProcessManager(abThread, Generic[T]):
                 process.join()
 
         except Exception as e:
-            raise e
+            self.on_exception(e)
 
     def action(self) -> None:
         pass

--- a/src/python_library/process/process.py
+++ b/src/python_library/process/process.py
@@ -44,7 +44,7 @@ class abProcess(Process, IProcess):
         try:
             self.action()
         except Exception as e:
-            raise e
+            self.on_exception(e)
 
     def start(self):
         self._event.clear()
@@ -63,14 +63,17 @@ class abProcess(Process, IProcess):
     def action(self) -> None:
         pass
 
+    def on_exception(self, e: Exception) -> None:
+        raise e
+
 
 class abProcessing(abProcess):
     def run(self) -> None:
-        try:
-            while not self.is_stop():
+        while not self.is_stop():
+            try:
                 self.action()
-        except Exception as e:
-            raise e
+            except Exception as e:
+                self.on_exception(e)
 
     @abstractmethod
     def action(self) -> None:

--- a/src/python_library/process/queue_process.py
+++ b/src/python_library/process/queue_process.py
@@ -90,11 +90,11 @@ class QueueProcess(abProcess, IQueueProcess[T], Generic[T]):
 
 class QueueProcessing(QueueProcess[T], Generic[T]):
     def run(self) -> None:
-        try:
-            while not self.is_stop():
+        while not self.is_stop():
+            try:
                 self.action()
-        except Exception as e:
-            raise e
+            except Exception as e:
+                self.on_exception(e)
 
     @abstractmethod
     def action(self) -> None:

--- a/src/python_library/thread/README.md
+++ b/src/python_library/thread/README.md
@@ -129,6 +129,26 @@ while True:
 
 `manager.stop()` 호출 시 관리 중인 모든 하위 스레드에도 `stop()`이 전파된다.
 
+### 예외 처리 (on_exception)
+
+`action()`에서 예외가 발생하면 `run()`이 이를 잡아 `on_exception(e)`를 호출한다.
+**기본 구현은 예외를 다시 던진다(fail-loud)** — 표준 `threading.Thread`와 동일하게
+단발형은 종료되고, 루프형(`abThreading`/`QueueThreading`)은 루프가 끝난다(fail-fast).
+라이브러리가 실패를 조용히 삼키지 않도록 한 의도적 기본값이다.
+
+"한 job이 실패해도 계속 도는" resilient 워커가 필요하면 `on_exception`을 오버라이드해
+예외를 삼킨다(다시 던지지 않는다).
+
+```python
+class MyWorker(QueueThreading):
+    def on_exception(self, e: Exception) -> None:
+        logger.error("job failed, continuing: %s", e)  # 삼키고 계속
+```
+
+스레드 예외는 `start()`/`join()` 호출 측으로 전파되지 않으므로(기본값은
+`threading.excepthook`으로 traceback 출력 후 종료), 호출 측이 실패를 인지해야 한다면
+`on_exception`에서 별도로 신호를 전달해야 한다.
+
 ### 이름 자동 생성
 
 `ClassNameGenerator`를 통해 이름을 지정하지 않으면 `MyWorkerThread1`, `MyWorkerThread2`처럼 클래스별로 순번이 붙는다.

--- a/src/python_library/thread/multi_thread_manager.py
+++ b/src/python_library/thread/multi_thread_manager.py
@@ -37,7 +37,7 @@ class MultiThreadManager(QueueThread[T], Generic[T]):
                 thread.join()
 
         except Exception as e:
-            raise e
+            self.on_exception(e)
 
     def action(self) -> None:
         pass

--- a/src/python_library/thread/queue_thread.py
+++ b/src/python_library/thread/queue_thread.py
@@ -98,11 +98,11 @@ class QueueThread(abThread, IQueueThread[T], Generic[T]):
 
 class QueueThreading(QueueThread[T], Generic[T]):
     def run(self) -> None:
-        try:
-            while not self.is_stop():
+        while not self.is_stop():
+            try:
                 self.action()
-        except Exception as e:
-            raise e
+            except Exception as e:
+                self.on_exception(e)
 
     @abstractmethod
     def action(self) -> None:

--- a/src/python_library/thread/thread.py
+++ b/src/python_library/thread/thread.py
@@ -55,11 +55,14 @@ class abThread(Thread, IThread):
         try:
             self.action()
         except Exception as e:
-            raise e
+            self.on_exception(e)
 
     @abstractmethod
     def action(self) -> None:
         pass
+
+    def on_exception(self, e: Exception) -> None:
+        raise e
 
 
 class abThreading(abThread):
@@ -67,8 +70,8 @@ class abThreading(abThread):
         super().__init__()
 
     def run(self) -> None:
-        try:
-            while not self.is_stop():
+        while not self.is_stop():
+            try:
                 self.action()
-        except Exception as e:
-            raise e
+            except Exception as e:
+                self.on_exception(e)

--- a/tests/test_thread/test_thread.py
+++ b/tests/test_thread/test_thread.py
@@ -1,4 +1,4 @@
-from python_library.thread.thread import abThread
+from python_library.thread.thread import abThread, abThreading
 
 
 class ThreadTest(abThread):
@@ -31,3 +31,73 @@ def test_threading():
     threading = ThreadingTest()
     threading.start()
     pass
+
+
+class RaisingThread(abThread):
+    def __init__(self):
+        super().__init__()
+        self.caught: list[Exception] = []
+
+    def action(self) -> None:
+        raise ValueError("boom")
+
+    def on_exception(self, e: Exception) -> None:
+        self.caught.append(e)
+
+
+def test_on_exception_called_on_single_shot():
+    # on_exception을 오버라이드해 삼키면(다시 던지지 않으면) 예외가 잡힌다
+    thread = RaisingThread()
+    thread.start()
+    thread.join()
+
+    assert len(thread.caught) == 1
+    assert isinstance(thread.caught[0], ValueError)
+    assert not thread.is_alive()
+
+
+class DefaultThread(abThread):
+    def action(self) -> None:
+        raise ValueError("boom")
+
+
+def test_default_on_exception_reraises(monkeypatch):
+    # 기본 on_exception은 예외를 다시 던진다(fail-loud) → threading.excepthook으로 전달
+    import threading
+
+    caught: list[BaseException] = []
+    monkeypatch.setattr(
+        threading, "excepthook", lambda args: caught.append(args.exc_value)
+    )
+
+    thread = DefaultThread()
+    thread.start()
+    thread.join()
+
+    assert len(caught) == 1
+    assert isinstance(caught[0], ValueError)
+    assert not thread.is_alive()
+
+
+class RaisingThreading(abThreading):
+    def __init__(self):
+        super().__init__()
+        self.caught: list[Exception] = []
+
+    def action(self) -> None:
+        raise ValueError("boom")
+
+    def on_exception(self, e: Exception) -> None:
+        self.caught.append(e)
+        if len(self.caught) >= 3:
+            self.stop()
+
+
+def test_loop_continues_when_on_exception_swallows():
+    # on_exception을 오버라이드해 삼키면 루프가 멈추지 않고 계속된다 (opt-in resilient)
+    thread = RaisingThreading()
+    thread.start()
+    thread.join()
+
+    assert len(thread.caught) == 3
+    assert not thread.is_alive()

--- a/uv.lock
+++ b/uv.lock
@@ -569,7 +569,7 @@ wheels = [
 
 [[package]]
 name = "python-library"
-version = "2.12.0"
+version = "2.13.0"
 source = { virtual = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
## Summary
- abThread/abProcess에 오버라이드 가능한 on_exception(e) 훅 추가. 기본은 예외 재던지기(fail-loud)로 실패를 조용히 삼키지 않는다.
- run()의 의미 없는 try/except Exception as e: raise e 제거.
- 단발형: action() 예외를 잡아 on_exception 호출 후 종료.
- 루프형(abThreading/QueueThreading/abProcessing/QueueProcessing): try를 루프 안으로 옮겨 기본 fail-fast, resilient는 on_exception 오버라이드로 opt-in.
- 매니저 2종도 상속된 on_exception 사용하도록 정리.
- thread/process README에 예외 처리 절 추가, on_exception 동작 테스트 추가.
- 버전 2.12.0 → 2.13.0 (MINOR: 하위 호환 기능 추가), uv.lock 최신화.

## Related Issues
- close #53